### PR TITLE
Fix: Add Promise as return type to save method

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -844,7 +844,7 @@ declare module "jspdf" {
       ry: number,
       style?: string | null
     ): jsPDF;
-    save(filename?: string, options?: { returnPromise?: boolean }): jsPDF;
+    save(filename?: string, options?: { returnPromise?: boolean }): jsPDF | Promise;
     saveGraphicsState(): jsPDF;
     setCharSpace(charSpace: number): jsPDF;
     setCreationDate(date?: Date | string): jsPDF;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -843,7 +843,7 @@ declare module "jspdf" {
       rx: number,
       ry: number,
       style?: string | null
-    ): jsPDF;;
+    ): jsPDF;
     save(filename: string, options: { returnPromise: true }): Promise<void>;
     save(filename?: string): jsPDF;
     saveGraphicsState(): jsPDF;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -843,8 +843,9 @@ declare module "jspdf" {
       rx: number,
       ry: number,
       style?: string | null
-    ): jsPDF;
-    save(filename?: string, options?: { returnPromise?: boolean }): jsPDF | Promise;
+    ): jsPDF;;
+    save(filename: string, options: { returnPromise: true }): Promise<void>;
+    save(filename?: string): jsPDF;
     saveGraphicsState(): jsPDF;
     setCharSpace(charSpace: number): jsPDF;
     setCreationDate(date?: Date | string): jsPDF;


### PR DESCRIPTION
The types of the jsPDF.save method only mention jsPDF itself, but if returnPromise options is set to true the function returns a promise.

Thanks for contributing to jsPDF! Please follow our
[Contribution Guidelines](https://github.com/MrRio/jsPDF/blob/master/CONTRIBUTING.md#pull-requests)
when creating a pull request.
