### PR TITLE
context2d: Fix default font behavior.

### DIFF
--- a/src/modules/context2d.js
+++ b/src/modules/context2d.js
@@ -74,7 +74,17 @@ import {
   jsPDFAPI.events.push([
     "initialized",
     function() {
-      this.context2d = new Context2D(this);
+      let context2d = null;
+      Object.defineProperty(this, "context2d", {
+        get: () => {
+          if (context2d === null) {
+            context2d = new Context2D(this);
+            // activate default font
+            context2d.font = context2d.font;
+          }
+          return context2d;
+        }
+      });
 
       f2 = this.internal.f2;
       getHorizontalCoordinateString = this.internal.getCoordinateString;

--- a/test/specs/context2d.spec.js
+++ b/test/specs/context2d.spec.js
@@ -164,6 +164,30 @@ describe("Context2D: standard tests", () => {
     comparePdf(doc.output(), "context2d-custom-fonts.pdf", "context2d");
   });
 
+  it("context2d: default font", () => {
+    const doc = new jsPDF({
+      orientation: "p",
+      unit: "pt",
+      format: "a4",
+      floatPrecision: 2
+    });
+    const ctx = doc.context2d;
+
+    expect(ctx.font).toEqual("10px sans-serif")
+    expect(doc.getFontSize()).toEqual(10)
+    expect(doc.getFont().fontName).toEqual("helvetica")
+
+    const writeArray = [];
+    doc.__private__.setCustomOutputDestination(writeArray);
+    ctx.fillText("test", 0, 10);
+
+    expect(writeArray).toEqual([
+      "1. w",
+      "BT\n/F1 10 Tf\n11.5 TL\n0 g\n0. 831.89 Td\n(test) Tj\nET",
+      "1. w"
+    ]);
+  });
+
   it("context2d: css color names", () => {
     var doc = new jsPDF({
       orientation: "p",


### PR DESCRIPTION
Hello, 

I've encountered an inconsistency of context2d text rendering.
Previous, if you used contex2d to "fillText" (with default font) on the first page, the current jsPDF font (and size) was used (not the context2d font). However, if you then "fillText" on the next page, suddenly the context2d font will be used. So you end up with text rendered in different fonts.

I propose with this PR that if you access the context2d for the first time, that we force apply the context2d font as the current jsPDF font. This makes rendering text consistent.

Of course, if someone changes the jsPDF font in the meantime, the problem is back. But I think this is a complete other topic. And a mix between two rendering methods are probably not that common.

Regards
Thomas