### PR TITLE
Fix margins type of TableConfig

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -607,7 +607,7 @@ declare module "jspdf" {
   export interface TableConfig {
     printHeaders?: boolean;
     autoSize?: boolean;
-    margins?: number;
+    margins?: { left?: number; top?: number; right?: number; bottom?: number };
     fontSize?: number;
     padding?: number;
     headerBackgroundColor?: string;


### PR DESCRIPTION
config.margins in [`TableConfig`](http://raw.githack.com/MrRio/jsPDF/master/docs/module-cell.html#~table) takes Object with margin values for `left`, `top`, `right` and `bottom` (update #3351)