### PR TITLE
Bug fix - use the proper "undefined" value

### DIFF
--- a/src/modules/context2d.js
+++ b/src/modules/context2d.js
@@ -1718,7 +1718,7 @@ import {
           tmpRect.w,
           tmpRect.h,
           null,
-          null,
+          undefined,
           angle
         );
         if (needsClipping) {
@@ -1734,7 +1734,7 @@ import {
         xRect.w,
         xRect.h,
         null,
-        null,
+        undefined,
         angle
       );
     }


### PR DESCRIPTION
Using "null" for the "compression" parameter causes the function's logic to not detect it as "unset" and will not apply the default setting.

resolves #3178

Thanks for contributing to jsPDF! Please follow our
[Contribution Guidelines](https://github.com/MrRio/jsPDF/blob/master/CONTRIBUTING.md#pull-requests)
when creating a pull request.
