### PR TITLE
Note that only TrueType can be embedded

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ loading polyfills multiple times. Might still be nifty for small applications or
 ## Use of Unicode Characters / UTF-8:
 
 The 14 standard fonts in PDF are limited to the ASCII-codepage. If you want to use UTF-8 you have to integrate a
-custom font, which provides the needed glyphs. jsPDF supports .ttf-files. So if you want to have for example
+custom font, which provides the needed glyphs. jsPDF **only** supports TrueType (.ttf) files. So if you want to have for example
 Chinese text in your pdf, your font has to have the necessary Chinese glyphs. So, check if your font supports
 the wanted glyphs or else it will show garbled characters instead of the right text.
 

--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -4938,6 +4938,7 @@ function jsPDF(options) {
 
   /**
    * Add a custom font to the current instance.
+   * Only TrueType fonts (.ttf) are currently supported.
    *
    * @param {string} postScriptName PDF specification full name for the font.
    * @param {string} id PDF-document-instance-specific label assinged to the font.


### PR DESCRIPTION
As mentioned in parallax#2830 it is only TrueType that can be embedded so it's good to make that clear.

Thanks for contributing to jsPDF! Please follow our
[Contribution Guidelines](https://github.com/MrRio/jsPDF/blob/master/CONTRIBUTING.md#pull-requests)
when creating a pull request.
