### PR TITLE
Improve roundToPrecision run time

### DIFF
--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -493,7 +493,11 @@ function jsPDF(options) {
     if (isNaN(number) || isNaN(tmpPrecision)) {
       throw new Error("Invalid argument passed to jsPDF.roundToPrecision");
     }
-    return number.toFixed(tmpPrecision).replace(/0+$/, "");
+    let rounded = number.toFixed(tmpPrecision);
+    while (rounded[rounded.length - 1] === "0") {
+      rounded = rounded.substr(0, rounded.length - 2);
+    }
+    return rounded;
   });
 
   // high precision float


### PR DESCRIPTION
Hello there,

Thank you for the amazing library!!

I'm using it generate some large reports on NodeJS  and am running into performance issues.
One of those issue is related to the `roundToPrecision` function which uses a regex replace which is very inefficient and can be replaced with a purer alternative.

I'll also continue  to investigate other potential bottlenecks.


Some benchmarks.
```
console.time('regex')
let a 
for(let i =0 ; i< 10000; i ++){
 a = Number(213121123123).toFixed(16).replace(/0+$/,'');
}
console.log(a)

console.timeEnd('regex')

console.time('pure')
for(let i =0 ; i< 10000; i ++){
    a = Number(213121123123).toFixed(16);
    while(a[a.length - 1] == 0){
        a = a.substring(0, a.length - 2)
    }
}
console.log(a)
console.timeEnd('pure')
```


```
213121123123.
regex: 45.596ms
213121123123.
pure: 10.759ms
```