### PR TITLE
Replace "can not" with "cannot" because it's grammatically correct

### DIFF
--- a/examples/js/ace.js
+++ b/examples/js/ace.js
@@ -501,7 +501,7 @@
     if (!Object.defineProperty || x) {
       var T = "Property description must be an object: ",
         N = "Object.defineProperty called on non-object: ",
-        C = "getters & setters can not be defined on this javascript engine";
+        C = "getters & setters cannot be defined on this javascript engine";
       Object.defineProperty = function(t, n, r) {
         if ((typeof t != "object" && typeof t != "function") || t === null)
           throw new TypeError(N + t);

--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -2730,7 +2730,7 @@ function jsPDF(options) {
 
     if (width > 14400 || height > 14400) {
       console.warn(
-        "A page in a PDF can not be wider or taller than 14400 userUnit. jsPDF limits the width/height to 14400"
+        "A page in a PDF cannot be wider or taller than 14400 userUnit. jsPDF limits the width/height to 14400"
       );
       width = Math.min(14400, width);
       height = Math.min(14400, height);


### PR DESCRIPTION
As documented in [Cannot vs. Can Not vs. Can’t—What’s the Difference?](https://www.grammarly.com/blog/cannot-or-can-not/) proper form in these cases is "cannot". This PR fixes/replaces two occurrences of "can not" with "cannot".