### PR TITLE
Fix ShadingPattern issues + eslint

### DIFF
--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -139,7 +139,6 @@ function Pattern(gState, matrix) {
   this.matrix = matrix;
 
   this.id = ""; // set by addPattern()
-  this.key = ""; // set by addPattern()
   this.objectNumber = -1; // will be set by putPattern()
 }
 
@@ -1471,7 +1470,6 @@ function jsPDF(options) {
     var prefix = pattern instanceof ShadingPattern ? "Sh" : "P";
     var patternKey = prefix + (Object.keys(patterns).length + 1).toString(10);
     pattern.id = patternKey;
-    pattern.key = key;
 
     patternMap[key] = patternKey;
     patterns[patternKey] = pattern;

--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -4330,7 +4330,7 @@ function jsPDF(options) {
   }
 
   var fillWithPattern = function(patternData, style) {
-    var patternId = patternData.id || patternMap[patternData.key];
+    var patternId = patternMap[patternData.key];
     var pattern = patterns[patternId];
 
     if (pattern instanceof ShadingPattern) {
@@ -4352,8 +4352,8 @@ function jsPDF(options) {
       // so we must flip them
       var matrix = new Matrix(1, 0, 0, -1, 0, getPageHeight());
 
-      if (pattern.matrix) {
-        matrix = matrix.multiply(pattern.matrix || identityMatrix);
+      if (patternData.matrix) {
+        matrix = matrix.multiply(patternData.matrix || identityMatrix);
         // we cannot apply a matrix to the pattern on use so we must abuse the pattern matrix and create new instances
         // for each use
         patternId = cloneTilingPattern.call(

--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -4330,7 +4330,7 @@ function jsPDF(options) {
   }
 
   var fillWithPattern = function(patternData, style) {
-    var patternId = patternData.id ?? patternMap[patternData.key];
+    var patternId = patternData.id || patternMap[patternData.key];
     var pattern = patterns[patternId];
 
     if (pattern instanceof ShadingPattern) {

--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -38,7 +38,7 @@ function PubSub(context) {
       );
     }
 
-    if (!topics.hasOwnProperty(topic)) {
+    if (!Object.prototype.hasOwnProperty.call(topics, topic)) {
       topics[topic] = {};
     }
 
@@ -62,7 +62,7 @@ function PubSub(context) {
   };
 
   this.publish = function(topic) {
-    if (topics.hasOwnProperty(topic)) {
+    if (Object.prototype.hasOwnProperty.call(topics, topic)) {
       var args = Array.prototype.slice.call(arguments, 1),
         tokens = [];
 
@@ -101,7 +101,7 @@ function GState(parameters) {
    */
   var supported = "opacity,stroke-opacity".split(",");
   for (var p in parameters) {
-    if (parameters.hasOwnProperty(p) && supported.indexOf(p) >= 0) {
+    if (Object.prototype.hasOwnProperty.call(parameters, p) && supported.indexOf(p) >= 0) {
       this[p] = parameters[p];
     }
   }
@@ -124,12 +124,12 @@ GState.prototype.equals = function equals(other) {
   var count = 0;
   for (p in this) {
     if (ignore.indexOf(p) >= 0) continue;
-    if (this.hasOwnProperty(p) && !other.hasOwnProperty(p)) return false;
+    if (Object.prototype.hasOwnProperty.call(this, p) && !Object.prototype.hasOwnProperty.call(other, p)) return false;
     if (this[p] !== other[p]) return false;
     count++;
   }
   for (p in other) {
-    if (other.hasOwnProperty(p) && ignore.indexOf(p) < 0) count--;
+    if (Object.prototype.hasOwnProperty.call(other, p) && ignore.indexOf(p) < 0) count--;
   }
   return count === 0;
 };
@@ -1035,7 +1035,7 @@ function jsPDF(options) {
   ) {
     // copying only those properties we can render.
     for (var property in documentProperties) {
-      if (documentProperties.hasOwnProperty(property) && properties[property]) {
+      if (Object.prototype.hasOwnProperty.call(documentProperties, property) && properties[property]) {
         documentProperties[property] = properties[property];
       }
     }
@@ -2027,10 +2027,10 @@ function jsPDF(options) {
 
   var putFonts = function() {
     for (var fontKey in fonts) {
-      if (fonts.hasOwnProperty(fontKey)) {
+      if (Object.prototype.hasOwnProperty.call(fonts, fontKey)) {
         if (
           putOnlyUsedFonts === false ||
-          (putOnlyUsedFonts === true && usedFonts.hasOwnProperty(fontKey))
+          (putOnlyUsedFonts === true && Object.prototype.hasOwnProperty.call(usedFonts, fontKey))
         ) {
           putFont(fonts[fontKey]);
         }
@@ -2073,7 +2073,7 @@ function jsPDF(options) {
 
   var putXObjects = function() {
     for (var xObjectKey in renderTargets) {
-      if (renderTargets.hasOwnProperty(xObjectKey)) {
+      if (Object.prototype.hasOwnProperty.call(renderTargets, xObjectKey)) {
         putXObject(renderTargets[xObjectKey]);
       }
     }
@@ -2230,7 +2230,7 @@ function jsPDF(options) {
   var putPatterns = function(deferredResourceDictionaryIds) {
     var patternKey;
     for (patternKey in patterns) {
-      if (patterns.hasOwnProperty(patternKey)) {
+      if (Object.prototype.hasOwnProperty.call(patterns, patternKey)) {
         if (patterns[patternKey] instanceof ShadingPattern) {
           putShadingPattern(patterns[patternKey]);
         } else if (patterns[patternKey] instanceof TilingPattern) {
@@ -2260,7 +2260,7 @@ function jsPDF(options) {
   var putGStates = function() {
     var gStateKey;
     for (gStateKey in gStates) {
-      if (gStates.hasOwnProperty(gStateKey)) {
+      if (Object.prototype.hasOwnProperty.call(gStates, gStateKey)) {
         putGState(gStates[gStateKey]);
       }
     }
@@ -2270,7 +2270,7 @@ function jsPDF(options) {
     out("/XObject <<");
     for (var xObjectKey in renderTargets) {
       if (
-        renderTargets.hasOwnProperty(xObjectKey) &&
+        Object.prototype.hasOwnProperty.call(renderTargets, xObjectKey) &&
         renderTargets[xObjectKey].objectNumber >= 0
       ) {
         out(
@@ -2305,10 +2305,10 @@ function jsPDF(options) {
     out("/Font <<");
 
     for (var fontKey in fonts) {
-      if (fonts.hasOwnProperty(fontKey)) {
+      if (Object.prototype.hasOwnProperty.call(fonts, fontKey)) {
         if (
           putOnlyUsedFonts === false ||
-          (putOnlyUsedFonts === true && usedFonts.hasOwnProperty(fontKey))
+          (putOnlyUsedFonts === true && Object.prototype.hasOwnProperty.call(usedFonts, fontKey))
         ) {
           out("/" + fontKey + " " + fonts[fontKey].objectNumber + " 0 R");
         }
@@ -2322,7 +2322,7 @@ function jsPDF(options) {
       out("/Shading <<");
       for (var patternKey in patterns) {
         if (
-          patterns.hasOwnProperty(patternKey) &&
+          Object.prototype.hasOwnProperty.call(patterns, patternKey) &&
           patterns[patternKey] instanceof ShadingPattern &&
           patterns[patternKey].objectNumber >= 0
         ) {
@@ -2342,7 +2342,7 @@ function jsPDF(options) {
       out("/Pattern <<");
       for (var patternKey in patterns) {
         if (
-          patterns.hasOwnProperty(patternKey) &&
+          Object.prototype.hasOwnProperty.call(patterns, patternKey) &&
           patterns[patternKey] instanceof API.TilingPattern &&
           patterns[patternKey].objectNumber >= 0 &&
           patterns[patternKey].objectNumber < objectOid // prevent cyclic dependencies
@@ -2363,7 +2363,7 @@ function jsPDF(options) {
       out("/ExtGState <<");
       for (gStateKey in gStates) {
         if (
-          gStates.hasOwnProperty(gStateKey) &&
+          Object.prototype.hasOwnProperty.call(gStates, gStateKey) &&
           gStates[gStateKey].objectNumber >= 0
         ) {
           out("/" + gStateKey + " " + gStates[gStateKey].objectNumber + " 0 R");
@@ -2860,7 +2860,7 @@ function jsPDF(options) {
     out("<<");
     out("/Producer (" + pdfEscape(encryptor("jsPDF " + jsPDF.version)) + ")");
     for (var key in documentProperties) {
-      if (documentProperties.hasOwnProperty(key) && documentProperties[key]) {
+      if (Object.prototype.hasOwnProperty.call(documentProperties, key) && documentProperties[key]) {
         out(
           "/" +
             key.substr(0, 1).toUpperCase() +
@@ -3906,21 +3906,21 @@ function jsPDF(options) {
         text = [];
         len = da.length;
         maxWidth = maxWidth !== 0 ? maxWidth : pageWidth;
-        for (var l = 0; l < len; l++) {
-          newY = l === 0 ? getVerticalCoordinate(y) : -leading;
-          newX = l === 0 ? getHorizontalCoordinate(x) : 0;
-          if (l < len - 1) {
+        for (var m = 0; m < len; m++) {
+          newY = m === 0 ? getVerticalCoordinate(y) : -leading;
+          newX = m === 0 ? getHorizontalCoordinate(x) : 0;
+          if (m < len - 1) {
             wordSpacingPerLine.push(
               hpf(
                 scale(
-                  (maxWidth - lineWidths[l]) / (da[l].split(" ").length - 1)
+                  (maxWidth - lineWidths[m]) / (da[m].split(" ").length - 1)
                 )
               )
             );
           } else {
             wordSpacingPerLine.push(0);
           }
-          text.push([da[l], newX, newY]);
+          text.push([da[m], newX, newY]);
         }
       } else {
         throw new Error(
@@ -4929,10 +4929,10 @@ function jsPDF(options) {
       fontStyle;
 
     for (fontName in fontmap) {
-      if (fontmap.hasOwnProperty(fontName)) {
+      if (Object.prototype.hasOwnProperty.call(fontmap, fontName)) {
         list[fontName] = [];
         for (fontStyle in fontmap[fontName]) {
-          if (fontmap[fontName].hasOwnProperty(fontStyle)) {
+          if (Object.prototype.hasOwnProperty.call(fontmap[fontName], fontStyle)) {
             list[fontName].push(fontStyle);
           }
         }
@@ -5517,7 +5517,7 @@ function jsPDF(options) {
     if (key && gStatesMap[key]) return;
     var duplicate = false;
     for (var s in gStates) {
-      if (gStates.hasOwnProperty(s)) {
+      if (Object.prototype.hasOwnProperty.call(gStates, s)) {
         if (gStates[s].equals(gState)) {
           duplicate = true;
           break;
@@ -5925,7 +5925,7 @@ function jsPDF(options) {
   // this is intentional as we allow plugins to override
   // built-ins
   for (var plugin in jsPDF.API) {
-    if (jsPDF.API.hasOwnProperty(plugin)) {
+    if (Object.prototype.hasOwnProperty.call(jsPDF.API, plugin)) {
       if (plugin === "events" && jsPDF.API.events.length) {
         (function(events, newEvents) {
           // jsPDF.API.events is a JS Array of Arrays


### PR DESCRIPTION
### Bugs fixed
- ~~Patterns was unable to work with all functions who use `fillWithPattern`.~~
I rollback on that but `fillWithPattern` should take pattern key or pattern object in parameter and not `patternData`. All datas are already in patterns.
- Shading patterns was not using scaling for its coordinates.
- `fillWithPattern` function was writing matrix every time for shading patterns but the parameter is optional.

### Tested with below code
```js
import { jsPDF } from "../../../ProjetJS/jsPDF/dist/jspdf.node.min.js";

const doc = new jsPDF();

const pattern = doc.ShadingPattern(
    "axial",
    [10, 100, 100, 10],
    [
        { offset: 0, color: [255, 0, 0] },
        { offset: 0.3, color: [255, 255, 0] },
        { offset: 0.5, color: [0, 255, 0] },
        { offset: 0.7, color: [0, 255, 255] },
        { offset: 1, color: [0, 0, 255] }
    ]
);

doc.advancedAPI(doc => {
    doc.addShadingPattern("testPattern", pattern);
});

doc.path([
    { op: "m", c: [10, 10] },
    { op: "l", c: [100, 10] },
    { op: "l", c: [100, 10] },
    { op: "l", c: [100, 100] },
    { op: "l", c: [10, 100] }
]);

doc.fill({key:"testPattern"});

doc.save();
```

### Result
![image](https://user-images.githubusercontent.com/28494372/185240789-9d2b86d4-68a5-4b94-abcf-791001406fc7.png)

