### PR TITLE
fix: disable prototype pollution via vfs module

### DIFF
--- a/src/modules/vfs.js
+++ b/src/modules/vfs.js
@@ -20,6 +20,11 @@ import { jsPDF } from "../jspdf.js";
   var _initializeVFS = function() {
     if (typeof this.internal.vFS === "undefined") {
       this.internal.vFS = {};
+      Object.defineProperty(this.internal.vFS, "__proto__", {
+        value: this.internal.vFS.__proto__,
+        configurable: false,
+        writable: false
+      });
     }
     return true;
   };

--- a/test/specs/vfs.spec.js
+++ b/test/specs/vfs.spec.js
@@ -1,10 +1,10 @@
 describe("Module: vFS", () => {
   beforeAll(loadGlobals);
-	it("addFileToVFS should not be able to change the prototype", () => {
+  it("addFileToVFS should not be able to change the prototype", () => {
     var doc = new jsPDF("p", "pt", "a4");
-		var t = () => doc.addFileToVFS("__proto__", "BADFACE");
-		expect(t).toThrow()
-	})
+    var t = () => doc.addFileToVFS("__proto__", "BADFACE");
+    expect(t).toThrow();
+  });
   it("addFileToVFS and positive getFileFromVFS", () => {
     var doc = new jsPDF("p", "pt", "a4");
     doc.addFileToVFS("test.pdf", "BADFACE");

--- a/test/specs/vfs.spec.js
+++ b/test/specs/vfs.spec.js
@@ -1,5 +1,10 @@
 describe("Module: vFS", () => {
   beforeAll(loadGlobals);
+	it("addFileToVFS should not be able to change the prototype", () => {
+    var doc = new jsPDF("p", "pt", "a4");
+		var t = () => doc.addFileToVFS("__proto__", "BADFACE");
+		expect(t).toThrow()
+	})
   it("addFileToVFS and positive getFileFromVFS", () => {
     var doc = new jsPDF("p", "pt", "a4");
     doc.addFileToVFS("test.pdf", "BADFACE");


### PR DESCRIPTION
Thanks for contributing to jsPDF! Please follow our
[Contribution Guidelines](https://github.com/MrRio/jsPDF/blob/master/CONTRIBUTING.md#pull-requests)
when creating a pull request.

Fixes prototype pollution vector in `addFileToVFS`