### PR TITLE
fix(types): document `worker` prop on .html

### DIFF
--- a/src/modules/html.js
+++ b/src/modules/html.js
@@ -1055,7 +1055,7 @@ import { globalObject } from "../libs/globalObject.js";
    * @param {number=} [options.windowWidth] The window width in CSS pixels. In contrast to the
    * <code>html2canvas.windowWidth</code> option, this option affects the actual container size while rendering and
    * does NOT affect CSS media queries. This option only has an effect, if the <code>width<code> option is also specified.
-   *
+   * @param {boolean=} [options.worker] Whether the function should be executed in a web worker
    * @example
    * var doc = new jsPDF();
    *

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -238,6 +238,7 @@ declare module "jspdf" {
     width?: number;
     windowWidth?: number;
     fontFaces?: HTMLFontFace[];
+    worker?: boolean;
   }
 
   //jsPDF plugin: viewerPreferences


### PR DESCRIPTION
Hey! Thanks for the library.

While using the library with Typescript I've noticed that [`worker` prop(required to use web workers) is missing](https://github.com/parallax/jsPDF/blob/2d9a91916471f1fbe465dbcdc05db0cf22d720ec/src/modules/html.js#L1085) on `.html` function. This adds it to Typescript + JSDoc.
