### PR TITLE
Add missing setFontType in definition file.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -904,6 +904,7 @@ declare module "jspdf" {
       fontWeight?: string | number
     ): jsPDF;
     setFontSize(size: number): jsPDF;
+    setFontType(style: string): jsPDF;
     setGState(gState: any): jsPDF;
     setLineCap(style: string | number): jsPDF;
     setLineDashPattern(dashArray: number[], dashPhase: number): jsPDF;


### PR DESCRIPTION
After converting my application to typescript, I noticed that setFontType was missing from the definitions file.

this pull request adds the missing type.