### PR TITLE
Make table config optional

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1073,7 +1073,7 @@ declare module "jspdf" {
       y: number,
       data: { [key: string]: string }[],
       headers: string[] | CellConfig[],
-      config: TableConfig
+      config?: TableConfig
     ): jsPDF;
     calculateLineHeight(
       headerNames: string[],


### PR DESCRIPTION
Looking both at the code https://github.com/parallax/jsPDF/blob/2d9a91916471f1fbe465dbcdc05db0cf22d720ec/src/modules/cell.js#L378-L384 and the tests https://github.com/parallax/jsPDF/blob/2d9a91916471f1fbe465dbcdc05db0cf22d720ec/test/specs/cell.spec.js#L85-L93

It seems like `config` is an optional argument.
