### PR TITLE
Fix: file-saver version to 1.3.8 in jsPDF 1.5.3.

### DIFF
--- a/build.browser.conf.js
+++ b/build.browser.conf.js
@@ -34,7 +34,7 @@ import './src/deprecated/from_html.js';
 import './src/deprecated/html2pdf.js';
 
 import './src/libs/Blob.js';
-import './node_modules/file-saver/src/FileSaver.js';
+import './node_modules/file-saver/FileSaver.js';
 import './node_modules/omggif/omggif.js';
 import './src/libs/adler32cs.js';
 import './src/libs/bidiEngine.js';

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "canvg": "1.5.3",
-    "file-saver": "eligrey/FileSaver.js#1.3.8",
+    "file-saver": "1.3.8",
     "html2canvas": "1.0.0-alpha.12",
     "omggif": "1.0.7",
     "promise-polyfill": "8.1.0",


### PR DESCRIPTION
It fixes issue #2603 

I only update version for file-saver dependency so it can download from npm repositories instead of github
