### PR TITLE
Fix Invalid String Length When Saving PDF #1724

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,6 @@
 name: Continous Integration
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test-saucelabs:

--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -3024,12 +3024,13 @@ function jsPDF(options) {
 
     let arrayBuffer = new ArrayBuffer(length);
     let uint8Array = new Uint8Array(arrayBuffer);
+    let index = 0;
 
     for (let contentItem of content) {
       for (let i = 0; i < contentItem.length; i++) {
-        uint8Array[i] = contentItem.charCodeAt(i);
+        uint8Array[index++] = contentItem.charCodeAt(i);
       }
-      uint8Array[contentItem.length] = 0x0a; // newline
+      uint8Array[index++] = 0x0a; // newline
     }
 
     return arrayBuffer;


### PR DESCRIPTION
Using ArrayBuffer instead of string can bypass the limitations.

> https://github.com/nodejs/node/issues/35973