### PR TITLE
feat: A new feature (Contributers add in readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,13 @@ You can find information about building and testing jsPDF in the
 - Our special thanks to GH Lee ([sphilee](https://github.com/sphilee)) for programming the ttf-file-support and providing a large and long sought after feature
 - Everyone else that's contributed patches or bug reports. You rock.
 
+## Thanks To All Our Contributors
+
+<a href="https://github.com/parallax/jsPDF/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=parallax/jsPDF" />
+</a>
+
+
 ## License (MIT)
 
 Copyright


### PR DESCRIPTION
The project contributors will be shown in the readme section
![Screenshot 2023-10-11 224649](https://github.com/parallax/jsPDF/assets/40211634/b3ed8546-f04f-41e2-9554-a8a9edc04940)

