### PR TITLE
Fix loading image from path and add test

### DIFF
--- a/src/modules/addimage.js
+++ b/src/modules/addimage.js
@@ -873,7 +873,7 @@ import { atob, btoa } from "../libs/AtobBtoa.js";
       getImageFileTypeByImageData(imageData) === UNKNOWN
     ) {
       imageData = unescape(imageData);
-      var tmpImageData = convertBase64ToBinaryString(imageData, false);
+      var tmpImageData = validateStringAsBase64(imageData) ? convertBase64ToBinaryString(imageData, false) : imageData;
 
       if (tmpImageData !== "") {
         imageData = tmpImageData;

--- a/test/specs/addimage.spec.js
+++ b/test/specs/addimage.spec.js
@@ -39,6 +39,27 @@ describe("Module: addimage", () => {
     expect(doc.__addimage__.sHashCode("testtest")).toEqual(-1145835484);
   });
 
+  it("image as path", () => {
+    const doc = new jsPDF({
+      orientation: "p",
+      unit: "pt",
+      format: "a4",
+      floatPrecision: 2
+    });
+    doc.addImage(
+      "test/reference/images/colortype_1_grayscale_8_bit_png",
+      "PNG",
+      100,
+      200,
+      280,
+      210,
+      undefined,
+      undefined
+    );
+
+    comparePdf(doc.output(), "colortype_1_grayscale_8_bit_png.pdf", "addimage");
+  });
+
   if (typeof global !== "object") {
     it("addImage: canvas in addImage", () => {
       var doc = new jsPDF();


### PR DESCRIPTION
This node package implementing atob does not throw if the string is not base64, thus making a call like `.addImage('path.jpg', ...`) render blank.

I wasn't sure on what the proper fix here, so I conditioned the call to the conversion with a validation on the string. Added a test, though I wasn't really able to run the tests locally. I'm not even sure why they were failing.

Thanks for contributing to jsPDF! Please follow our
[Contribution Guidelines](https://github.com/MrRio/jsPDF/blob/master/CONTRIBUTING.md#pull-requests)
when creating a pull request.
