### PR TITLE
fix `getJpegInfo` to skip DHT marker

### DIFF
--- a/src/modules/jpeg_support.js
+++ b/src/modules/jpeg_support.js
@@ -17,16 +17,16 @@ import { jsPDF } from "../jspdf.js";
   "use strict";
 
   /**
-   * 0xc0 (SOF) Huffman  - Baseline DCT
-   * 0xc1 (SOF) Huffman  - Extended sequential DCT
+   * 0xc0 (SOF0) Huffman - Baseline DCT
+   * 0xc1 (SOF1) Huffman - Extended sequential DCT
    * 0xc2 Progressive DCT (SOF2)
    * 0xc3 Spatial (sequential) lossless (SOF3)
-   * 0xc4 Differential sequential DCT (SOF5)
-   * 0xc5 Differential progressive DCT (SOF6)
-   * 0xc6 Differential spatial (SOF7)
-   * 0xc7
+   * 0xc4 Define Huffman Tables (DHT) - skip
+   * 0xc5 Differential sequential DCT (SOF5)
+   * 0xc6 Differential progressive DCT (SOF6)
+   * 0xc7 Differential spatial (SOF7)
    */
-  var markers = [0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7];
+  var markers = [0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7];
 
   //takes a string imgData containing the raw bytes of
   //a jpeg image and returns [width, height]


### PR DESCRIPTION
Fixes #3318.

`getJpegInfo` now skips the DHT marker (`0xc4`) because that marker is not a SOF (start of frame) marker and therefore the segment to follow does not have the size information.