### PR TITLE
Remove duplicated function "ga"

### DIFF
--- a/src/libs/WebPDecoder.js
+++ b/src/libs/WebPDecoder.js
@@ -3179,9 +3179,6 @@ function WebPDecoder(imageData) {
       Ga(a, b, c, d, e);
       d[e + 3] = 255;
     }
-    function ga(a, b) {
-      return 0 > a ? 0 : a > b ? b : a;
-    }
     function la(a, b, c) {
       self[a] = function(a, e, f, g, h, k, l, m, n) {
         for (var d = m + (n & -2) * c; m != d; )


### PR DESCRIPTION
When using this library through ClojureScript is put through the Google Closure compiler, which actually crashes on this duplicated function definition.