### PR TITLE
Add vertical offset option for outline module

### DIFF
--- a/src/modules/outline.js
+++ b/src/modules/outline.js
@@ -121,7 +121,7 @@ import { jsPDF } from "../jspdf.js";
       };
 
       /**
-       * Options: pageNumber
+       * Options: pageNumber, pageOffsetY
        */
       pdf.outline.add = function(parent, title, options) {
         var item = {
@@ -219,7 +219,7 @@ import { jsPDF } from "../jspdf.js";
                   "[" +
                   info.objId +
                   " 0 R /XYZ 0 " +
-                  getVerticalCoordinateString(0) +
+                  getVerticalCoordinateString(item.options.pageOffsetY || 0) +
                   " 0]"
               );
               // this line does not work on all clients (pageNumber instead of page ref)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -274,6 +274,7 @@ declare module "jspdf" {
   }
   export interface OutlineOptions {
     pageNumber: number;
+    pageOffsetY?: number;
   }
   // jsPDF plugin: AcroForm
   export abstract class AcroFormField {}


### PR DESCRIPTION
Currently the outline module only supports linking to the top of a page.
It is often desirable to have the table of contents link to not only a page, but a specific location on the page, ex. to the start of a specific chapter or sub heading.
This PR adds an option (pageOffsetY) to the outline.add function options, which offsets the linked location from the top of the given page by the given number of units.

Relevant issue: #48 