### PR TITLE
arguments[6] added to src/module/cell.js

### DIFF
--- a/src/modules/cell.js
+++ b/src/modules/cell.js
@@ -278,7 +278,8 @@ import { jsPDF } from "../jspdf.js";
         arguments[2],
         arguments[3],
         arguments[4],
-        arguments[5]
+        arguments[5],
+        arguments[6]
       );
     }
     _initialize.call(this);


### PR DESCRIPTION
bug : Resolve issue with invalid 'align' parameter in cell method

Resolve the issue with the 'align' parameter by ensuring it is 
correctly passed to the Cell constructor and utilized in text positioning. 
This enhancement addresses alignment inconsistencies in cell rendering.

Fixes #3194