### PR TITLE
Enhanced PDF Test Reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 node_modules/
 coverage/
 npm-debug.log
+test/actual/*.pdf

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,12 +32,12 @@
         "docdash": "^1.2.0",
         "eslint": "^7.4.0",
         "eslint-plugin-jasmine": "^4.1.1",
+        "express": "^4.18.2",
         "folder-delete": "^1.0.4",
         "inquirer": "^6.5.2",
         "jasmine": "3.5.0",
         "jasmine-core": "3.5.0",
         "jasmine-expect": "4.0.3",
-        "js-yaml": "3.13.1",
         "jsdoc": "^3.6.3",
         "karma": "5.1.0",
         "karma-babel-preprocessor": "8.0.1",
@@ -45,8 +45,9 @@
         "karma-coverage": "2.0.2",
         "karma-firefox-launcher": "1.3.0",
         "karma-ie-launcher": "1.0.0",
-        "karma-jasmine": "3.3.1",
+        "karma-jasmine": "^3.3.1",
         "karma-jasmine-matchers": "4.0.2",
+        "karma-mocha": "^2.0.1",
         "karma-mocha-reporter": "2.2.5",
         "karma-rollup-preprocessor": "^7.0.7",
         "karma-sauce-launcher": "4.1.5",
@@ -66,6 +67,7 @@
         "rollup-plugin-preprocess": "0.0.4",
         "rollup-plugin-terser": "^6.1.0",
         "typescript": "^5.6.2",
+        "webpack": "^5.97.1",
         "yarpm": "^0.2.1"
       },
       "optionalDependencies": {
@@ -440,29 +442,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/browserslist": {
-      "version": "4.16.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
-      "dev": true,
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001219",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.723",
-        "escalade": "^3.1.1",
-        "node-releases": "^1.1.71"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
-    },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -476,27 +455,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/electron-to-chromium": {
-      "version": "1.3.779",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.779.tgz",
-      "integrity": "sha512-nreave0y/1Qhmo8XtO6C/LpawNyC6U26+q7d814/e+tIqUK073pM+4xW7WUXyqCRa5K4wdxHmNMBAi8ap9nEew==",
-      "dev": true
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/node-releases": {
-      "version": "1.1.73",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
-      "dev": true
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
       "version": "6.3.0",
@@ -1651,6 +1609,64 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@koa/cors": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-3.1.0.tgz",
@@ -1782,6 +1798,26 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1807,9 +1843,9 @@
       "dev": true
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "node_modules/@types/keyv": {
@@ -2089,6 +2125,164 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "dev": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "dev": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "dev": true
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -2096,13 +2290,13 @@
       "dev": true
     },
     "node_modules/accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
       "dependencies": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       },
       "engines": {
         "node": ">= 0.6"
@@ -2177,9 +2371,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2190,6 +2384,54 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^6.9.1"
       }
     },
     "node_modules/ansi-colors": {
@@ -2425,6 +2667,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true
+    },
     "node_modules/arraybuffer.slice": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
@@ -2600,29 +2848,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/babel-plugin-polyfill-corejs3/node_modules/browserslist": {
-      "version": "4.16.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
-      "dev": true,
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001219",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.723",
-        "escalade": "^3.1.1",
-        "node-releases": "^1.1.71"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs3/node_modules/core-js-compat": {
       "version": "3.15.2",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.2.tgz",
@@ -2636,27 +2861,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
-    },
-    "node_modules/babel-plugin-polyfill-corejs3/node_modules/electron-to-chromium": {
-      "version": "1.3.779",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.779.tgz",
-      "integrity": "sha512-nreave0y/1Qhmo8XtO6C/LpawNyC6U26+q7d814/e+tIqUK073pM+4xW7WUXyqCRa5K4wdxHmNMBAi8ap9nEew==",
-      "dev": true
-    },
-    "node_modules/babel-plugin-polyfill-corejs3/node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/babel-plugin-polyfill-corejs3/node_modules/node-releases": {
-      "version": "1.1.73",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
-      "dev": true
     },
     "node_modules/babel-plugin-polyfill-corejs3/node_modules/semver": {
       "version": "7.0.0",
@@ -2937,24 +3141,27 @@
       "dev": true
     },
     "node_modules/body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
       "dependencies": {
-        "bytes": "3.1.0",
-        "content-type": "~1.0.4",
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.7.2",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.7.0",
-        "raw-body": "2.4.0",
-        "type-is": "~1.6.17"
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/body-parser/node_modules/debug": {
@@ -2966,16 +3173,83 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/body-parser/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "node_modules/body-parser/node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/body-parser/node_modules/qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/body-parser/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true,
       "engines": {
         "node": ">=0.6"
@@ -3145,25 +3419,35 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.13.0.tgz",
-      "integrity": "sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==",
+      "version": "4.24.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
+      "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001093",
-        "electron-to-chromium": "^1.3.488",
-        "escalade": "^3.0.1",
-        "node-releases": "^1.1.58"
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/browserslist"
       }
     },
     "node_modules/btoa": {
@@ -3255,9 +3539,9 @@
       }
     },
     "node_modules/bytes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
       "engines": {
         "node": ">= 0.8"
@@ -3309,6 +3593,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
@@ -3347,14 +3660,24 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001245",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
-      "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
+      "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/canvg": {
       "version": "3.0.6",
@@ -3571,6 +3894,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -3711,12 +4043,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "node_modules/colorette": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
     "node_modules/colors": {
@@ -3980,21 +4306,41 @@
       "dev": true
     },
     "node_modules/content-disposition": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dev": true,
       "dependencies": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.1"
       },
       "engines": {
         "node": ">= 0.6"
       }
     },
+    "node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -4017,6 +4363,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "dev": true
     },
     "node_modules/cookies": {
       "version": "0.8.0",
@@ -4556,10 +4908,14 @@
       }
     },
     "node_modules/destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
     },
     "node_modules/detect-node": {
       "version": "2.0.4",
@@ -4758,6 +5114,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -4781,9 +5151,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.492",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.492.tgz",
-      "integrity": "sha512-AD6v9Y2wN0HuoRH4LwCmlSHjkKq51D1U52bTuvM5uPzisbHVm3Hms15c42TBFLewxnSqxAynK/tbeaUi4Rnjqw==",
+      "version": "1.5.76",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
+      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -4904,6 +5274,19 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
+      "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -4953,6 +5336,42 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
+      "dev": true
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -4983,9 +5402,9 @@
       "dev": true
     },
     "node_modules/escalade": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.1.tgz",
-      "integrity": "sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -5070,12 +5489,12 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "dependencies": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       },
       "engines": {
@@ -5209,13 +5628,22 @@
       }
     },
     "node_modules/esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "dependencies": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
       },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -5362,6 +5790,205 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/express/node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "dev": true
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/express/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/express/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true
+    },
+    "node_modules/express/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/ext-list": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
@@ -5470,6 +6097,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
       "dev": true
     },
     "node_modules/fd-slicer": {
@@ -5709,6 +6342,15 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -5770,10 +6412,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -5797,6 +6442,30 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
+      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "dunder-proto": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "function-bind": "^1.1.2",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-proxy": {
@@ -5862,6 +6531,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
+    },
     "node_modules/global-agent": {
       "version": "2.1.12",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.12.tgz",
@@ -5909,6 +6584,18 @@
       "dependencies": {
         "define-properties": "^1.1.3"
       },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6068,9 +6755,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "node_modules/graceful-readlink": {
@@ -6154,9 +6841,9 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -6233,6 +6920,18 @@
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/header-case": {
@@ -6624,6 +7323,15 @@
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-arguments": {
@@ -7102,19 +7810,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
-    "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/js2xmlparser": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.1.tgz",
@@ -7195,6 +7890,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "node_modules/json-schema": {
@@ -7425,6 +8126,15 @@
       "dev": true,
       "dependencies": {
         "add-matchers": "0.6.2"
+      }
+    },
+    "node_modules/karma-mocha": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-2.0.1.tgz",
+      "integrity": "sha512-Tzd5HBjm8his2OA4bouAsATYEpZrp9vC7z5E5j4C5Of5Rrs1jY67RAwXNcVmd/Bnk1wgvQRou0zGVLey44G4tQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.3"
       }
     },
     "node_modules/karma-mocha-reporter": {
@@ -8063,6 +8773,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/loader-runner": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
     "node_modules/local-web-server": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/local-web-server/-/local-web-server-4.2.1.tgz",
@@ -8652,6 +9371,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -8676,6 +9404,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -8725,21 +9462,21 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "dependencies": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -8896,13 +9633,19 @@
       "dev": true
     },
     "node_modules/negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -8921,9 +9664,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.59",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.59.tgz",
-      "integrity": "sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
     },
     "node_modules/node-version-matches": {
@@ -9062,10 +9805,13 @@
       "dev": true
     },
     "node_modules/object-inspect": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -9479,6 +10225,12 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "devOptional": true
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -9598,6 +10350,19 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -9804,18 +10569,67 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dev": true,
       "dependencies": {
-        "bytes": "3.1.0",
-        "http-errors": "1.7.2",
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/readable-stream": {
@@ -9985,6 +10799,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10482,15 +11305,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
-    "node_modules/saucelabs/node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/saucelabs/node_modules/form-data": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -10706,6 +11520,24 @@
         "node": ">=10"
       }
     },
+    "node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/seek-bzip": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
@@ -10765,6 +11597,124 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/send/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/send/node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true
+    },
+    "node_modules/send/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/sentence-case": {
@@ -10874,6 +11824,30 @@
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
     },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "dev": true,
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -10924,6 +11898,78 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -11078,9 +12124,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -11521,6 +12567,15 @@
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
@@ -11607,6 +12662,176 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz",
+      "integrity": "sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "serialize-javascript": "^6.0.2",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/terser-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/terser": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
+      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/terser/node_modules/commander": {
@@ -11982,6 +13207,36 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/upper-case": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.1.tgz",
@@ -12138,6 +13393,19 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/watchpack": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+      "dev": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -12189,6 +13457,79 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/webpack": {
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.17.1",
+        "es-module-lexer": "^1.2.1",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.2.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.3.10",
+        "watchpack": "^2.4.1",
+        "webpack-sources": "^3.2.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true
+    },
+    "node_modules/webpack/node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "local-web-server": "^4.2.1",
         "log-utils": "^1.0.0",
         "markdown": "0.5.0",
+        "nodemon": "^3.1.9",
         "preprocess": "^3.2.0",
         "prettier": "^1.19.1",
         "regenerator-runtime": "^0.13.5",
@@ -2492,9 +2493,9 @@
       "dev": true
     },
     "node_modules/anymatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -3838,24 +3839,41 @@
       "dev": true
     },
     "node_modules/chokidar": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-      "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
       "dependencies": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "glob-parent": "~5.1.0",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.4.0"
+        "readdirp": "~3.6.0"
       },
       "engines": {
         "node": ">= 8.10.0"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
       "optionalDependencies": {
-        "fsevents": "~2.1.2"
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/chownr": {
@@ -6520,9 +6538,9 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -7127,6 +7145,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.2.1",
@@ -9513,9 +9537,9 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -9688,6 +9712,46 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
+      "integrity": "sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/nopt": {
@@ -10382,6 +10446,12 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true
+    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -10654,9 +10724,9 @@
       "dev": true
     },
     "node_modules/readdirp": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -11978,6 +12048,30 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -12966,6 +13060,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -13135,6 +13238,12 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
     },
     "node_modules/underscore": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "local-web-server": "^4.2.1",
     "log-utils": "^1.0.0",
     "markdown": "0.5.0",
+    "nodemon": "^3.1.9",
     "preprocess": "^3.2.0",
     "prettier": "^1.19.1",
     "regenerator-runtime": "^0.13.5",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "docdash": "^1.2.0",
     "eslint": "^7.4.0",
     "eslint-plugin-jasmine": "^4.1.1",
+    "express": "^4.18.2",
     "folder-delete": "^1.0.4",
     "inquirer": "^6.5.2",
     "jasmine": "3.5.0",
@@ -64,8 +65,9 @@
     "karma-coverage": "2.0.2",
     "karma-firefox-launcher": "1.3.0",
     "karma-ie-launcher": "1.0.0",
-    "karma-jasmine": "3.3.1",
+    "karma-jasmine": "^3.3.1",
     "karma-jasmine-matchers": "4.0.2",
+    "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "2.2.5",
     "karma-rollup-preprocessor": "^7.0.7",
     "karma-sauce-launcher": "4.1.5",
@@ -85,6 +87,7 @@
     "rollup-plugin-preprocess": "0.0.4",
     "rollup-plugin-terser": "^6.1.0",
     "typescript": "^5.6.2",
+    "webpack": "^5.97.1",
     "yarpm": "^0.2.1"
   },
   "scripts": {
@@ -107,7 +110,8 @@
     "prettier": "prettier --write \"*.{js,ts,md,css,json}\" \"{spec,examples,src,types}/**/*.{js,ts,md,css,json}\"",
     "lint": "prettier --check \"*.{js,ts,md,css,json}\" \"{spec,examples,src,types}/**/*.{js,ts,md,css,json}\"",
     "pregenerate-docs": "node deletedocs.js",
-    "generate-docs": "jsdoc -c jsdoc.json --readme README.md"
+    "generate-docs": "jsdoc -c jsdoc.json --readme README.md",
+    "test-report": "node test/report/server.js"
   },
   "browserslist": [
     "last 2 versions",

--- a/test/report/generate-report-data.js
+++ b/test/report/generate-report-data.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+
+function generateReportData(testResults) {
+    const summary = {
+        total: testResults.total,
+        passed: testResults.passed,
+        skipped: testResults.skipped,
+        failed: testResults.failed
+    };
+
+    const failures = testResults.failures.map(failure => ({
+        name: failure.name,
+        actualPdf: failure.actualPdf,
+        referencePdf: failure.referencePdf,
+        differences: {
+            total: failure.differences.total,
+            patterns: failure.differences.patterns.map(pattern => ({
+                type: pattern.type,
+                count: pattern.count,
+                sample: {
+                    expected: pattern.sample.expected,
+                    actual: pattern.sample.actual
+                }
+            }))
+        }
+    }));
+
+    return {
+        summary,
+        failures
+    };
+}
+
+function writeReportData(data) {
+    const reportDir = path.join(__dirname);
+    const dataFile = path.join(reportDir, 'test-results.js');
+    
+    const content = `window.TEST_RESULTS = ${JSON.stringify(data, null, 2)};`;
+    
+    fs.writeFileSync(dataFile, content);
+}
+
+module.exports = {
+    generateReportData,
+    writeReportData
+}; 

--- a/test/report/generate-report-data.js
+++ b/test/report/generate-report-data.js
@@ -2,34 +2,8 @@ const fs = require('fs');
 const path = require('path');
 
 function generateReportData(testResults) {
-    const summary = {
-        total: testResults.total,
-        passed: testResults.passed,
-        skipped: testResults.skipped,
-        failed: testResults.failed
-    };
-
-    const failures = testResults.failures.map(failure => ({
-        name: failure.name,
-        actualPdf: failure.actualPdf,
-        referencePdf: failure.referencePdf,
-        differences: {
-            total: failure.differences.total,
-            patterns: failure.differences.patterns.map(pattern => ({
-                type: pattern.type,
-                count: pattern.count,
-                sample: {
-                    expected: pattern.sample.expected,
-                    actual: pattern.sample.actual
-                }
-            }))
-        }
-    }));
-
-    return {
-        summary,
-        failures
-    };
+    // Pass through the test results directly since they're already in the correct format
+    return testResults;
 }
 
 function writeReportData(data) {

--- a/test/report/index.html
+++ b/test/report/index.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>jsPDF Test Report</title>
+    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@radix-ui/themes@2.0.0/styles.css">
+    <script src="test-results.js"></script>
+    <style>
+        :root {
+            --background: 0 0% 100%;
+            --foreground: 222.2 84% 4.9%;
+            --muted: 210 40% 96.1%;
+            --muted-foreground: 215.4 16.3% 46.9%;
+            --popover: 0 0% 100%;
+            --popover-foreground: 222.2 84% 4.9%;
+            --card: 0 0% 100%;
+            --card-foreground: 222.2 84% 4.9%;
+            --border: 214.3 31.8% 91.4%;
+            --input: 214.3 31.8% 91.4%;
+            --primary: 222.2 47.4% 11.2%;
+            --primary-foreground: 210 40% 98%;
+            --secondary: 210 40% 96.1%;
+            --secondary-foreground: 222.2 47.4% 11.2%;
+            --accent: 210 40% 96.1%;
+            --accent-foreground: 222.2 47.4% 11.2%;
+            --destructive: 0 84.2% 60.2%;
+            --destructive-foreground: 210 40% 98%;
+            --ring: 215 20.2% 65.1%;
+            --radius: 0.5rem;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+            background-color: hsl(var(--background));
+            color: hsl(var(--foreground));
+        }
+
+        .layout {
+            display: grid;
+            grid-template-columns: 300px 1fr;
+            height: 100vh;
+        }
+
+        .sidebar {
+            border-right: 1px solid hsl(var(--border));
+            padding: 1rem;
+            overflow-y: auto;
+        }
+
+        .main {
+            padding: 1rem;
+            overflow-y: auto;
+        }
+
+        .test-item {
+            padding: 0.75rem;
+            border: 1px solid hsl(var(--border));
+            border-radius: var(--radius);
+            margin-bottom: 0.5rem;
+            cursor: pointer;
+        }
+
+        .test-item:hover {
+            background-color: hsl(var(--muted));
+        }
+
+        .test-item.failed {
+            border-color: hsl(var(--destructive));
+        }
+
+        .pdf-viewer {
+            width: 100%;
+            height: calc(100vh - 2rem);
+            border: 1px solid hsl(var(--border));
+            border-radius: var(--radius);
+        }
+
+        .viewer-controls {
+            display: flex;
+            gap: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .button {
+            padding: 0.5rem 1rem;
+            background-color: hsl(var(--primary));
+            color: hsl(var(--primary-foreground));
+            border: none;
+            border-radius: var(--radius);
+            cursor: pointer;
+        }
+
+        .button:hover {
+            opacity: 0.9;
+        }
+
+        .button.secondary {
+            background-color: hsl(var(--secondary));
+            color: hsl(var(--secondary-foreground));
+        }
+
+        .hex-view {
+            font-family: monospace;
+            white-space: pre-wrap;
+            padding: 1rem;
+            background-color: hsl(var(--muted));
+            border-radius: var(--radius);
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="text/babel">
+        function App() {
+            const [selectedTest, setSelectedTest] = React.useState(null);
+            const [viewMode, setViewMode] = React.useState('actual');
+            const [testResults, setTestResults] = React.useState(window.TEST_RESULTS);
+
+            return (
+                <div className="layout">
+                    <div className="sidebar">
+                        <h2>Test Summary</h2>
+                        <div style={{ margin: '1rem 0' }}>
+                            <div>Total: {testResults.summary.total}</div>
+                            <div style={{ color: 'green' }}>Passed: {testResults.summary.passed}</div>
+                            <div style={{ color: 'orange' }}>Skipped: {testResults.summary.skipped}</div>
+                            <div style={{ color: 'red' }}>Failed: {testResults.summary.failed}</div>
+                        </div>
+                        <h3>Failed Tests</h3>
+                        {testResults.failures.map((test, index) => (
+                            <div 
+                                key={index}
+                                className="test-item failed"
+                                onClick={() => setSelectedTest(test)}
+                            >
+                                <div>{test.name}</div>
+                                <div style={{ fontSize: '0.875rem', color: 'hsl(var(--muted-foreground))' }}>
+                                    {test.differences.total} differences
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                    <div className="main">
+                        {selectedTest ? (
+                            <>
+                                <div className="viewer-controls">
+                                    <button 
+                                        className={`button ${viewMode === 'actual' ? '' : 'secondary'}`}
+                                        onClick={() => setViewMode('actual')}
+                                    >
+                                        Actual
+                                    </button>
+                                    <button 
+                                        className={`button ${viewMode === 'reference' ? '' : 'secondary'}`}
+                                        onClick={() => setViewMode('reference')}
+                                    >
+                                        Reference
+                                    </button>
+                                    <button 
+                                        className={`button ${viewMode === 'hex' ? '' : 'secondary'}`}
+                                        onClick={() => setViewMode('hex')}
+                                    >
+                                        Hex Diff
+                                    </button>
+                                </div>
+                                {viewMode === 'hex' ? (
+                                    <div className="hex-view">
+                                        {/* Placeholder for hex diff */}
+                                        Hex diff view coming soon...
+                                    </div>
+                                ) : (
+                                    <iframe 
+                                        className="pdf-viewer"
+                                        src={viewMode === 'actual' ? selectedTest.actualPdf : selectedTest.referencePdf}
+                                    />
+                                )}
+                            </>
+                        ) : (
+                            <div style={{ padding: '2rem', textAlign: 'center' }}>
+                                Select a test from the sidebar to view details
+                            </div>
+                        )}
+                    </div>
+                </div>
+            );
+        }
+
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(<App />);
+    </script>
+</body>
+</html> 

--- a/test/report/index.html
+++ b/test/report/index.html
@@ -3,12 +3,41 @@
 <head>
     <title>jsPDF Test Report</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
     <style>
         /* Preserve existing styles that are still needed */
-        .pdf-container iframe {
+        .pdf-container {
             width: 100%;
             height: 800px;
-            border: none;
+            position: relative;
+            overflow: hidden;
+            background: #525659;
+            display: flex;
+            flex-direction: column;
+        }
+        .pdf-canvas-container {
+            flex: 1;
+            position: relative;
+            overflow: hidden;
+            cursor: grab;
+        }
+        .pdf-canvas-container.panning {
+            cursor: grabbing;
+        }
+        .pdf-canvas-wrapper {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            overflow: auto;
+        }
+        .pdf-canvas {
+            position: relative;
+            margin: 0 auto;
+            display: block;
+            user-select: none;
+            -webkit-user-select: none;
         }
         .differences {
             white-space: pre-wrap;
@@ -63,6 +92,36 @@
             width: 1rem;
             height: 1rem;
         }
+        .pdf-controls {
+            padding: 0.75rem;
+            background: rgba(0, 0, 0, 0.5);
+            display: flex;
+            gap: 1rem;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+        .pdf-controls button {
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            background: rgba(255, 255, 255, 0.2);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            color: white;
+            cursor: pointer;
+        }
+        .pdf-controls button:hover {
+            background: rgba(255, 255, 255, 0.3);
+        }
+        .pdf-controls input {
+            width: 4rem;
+            padding: 0.25rem;
+            border-radius: 0.25rem;
+            background: rgba(255, 255, 255, 0.1);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            color: white;
+            text-align: center;
+        }
     </style>
 </head>
 <body class="antialiased">
@@ -95,8 +154,16 @@
 
     <script>
         let selectedItem = null;
+        let currentPdfState = {
+            scale: 1.0,
+            page: 1,
+            actualPdf: null,
+            referencePdf: null
+        };
 
         const documentIcon = `<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><line x1="10" y1="9" x2="8" y2="9"></line></svg>`;
+
+        pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
 
         function formatSummary(results) {
             return `
@@ -119,7 +186,188 @@
             `;
         }
 
-        function showPdfComparison(item) {
+        async function loadPdf(url, containerId) {
+            try {
+                const loadingTask = pdfjsLib.getDocument(url);
+                const pdf = await loadingTask.promise;
+                const container = document.getElementById(containerId);
+                const canvas = container.querySelector('canvas');
+                const context = canvas.getContext('2d');
+
+                // Store PDF reference
+                if (containerId === 'actualPdfContainer') {
+                    currentPdfState.actualPdf = pdf;
+                } else {
+                    currentPdfState.referencePdf = pdf;
+                }
+
+                // Update page count in controls
+                const pageCount = pdf.numPages;
+                container.querySelector('.page-count').textContent = pageCount;
+
+                // Calculate initial scale to fit width
+                const page = await pdf.getPage(1);
+                const viewport = page.getViewport({ scale: 1.0 });
+                const containerWidth = container.querySelector('.pdf-canvas-container').clientWidth;
+                const initialScale = (containerWidth - 40) / viewport.width; // 40px padding
+                currentPdfState.scale = initialScale;
+
+                // Update zoom display
+                document.querySelectorAll('.pdf-controls span:last-of-type').forEach(span => {
+                    span.textContent = `${Math.round(initialScale * 100)}%`;
+                });
+
+                // Render current page
+                await renderPage(pdf, currentPdfState.page, currentPdfState.scale, canvas, context);
+
+                return pdf;
+            } catch (error) {
+                console.error('Error loading PDF:', error);
+            }
+        }
+
+        async function renderPage(pdf, pageNumber, scale, canvas, context) {
+            const page = await pdf.getPage(pageNumber);
+            const pixelRatio = window.devicePixelRatio || 1;
+            const viewport = page.getViewport({ scale: scale * pixelRatio });
+
+            canvas.width = viewport.width;
+            canvas.height = viewport.height;
+            canvas.style.width = `${viewport.width / pixelRatio}px`;
+            canvas.style.height = `${viewport.height / pixelRatio}px`;
+
+            await page.render({
+                canvasContext: context,
+                viewport
+            }).promise;
+        }
+
+        async function updateBothPdfs() {
+            if (currentPdfState.actualPdf) {
+                const actualCanvas = document.querySelector('#actualPdfContainer canvas');
+                await renderPage(
+                    currentPdfState.actualPdf,
+                    currentPdfState.page,
+                    currentPdfState.scale,
+                    actualCanvas,
+                    actualCanvas.getContext('2d')
+                );
+            }
+            if (currentPdfState.referencePdf) {
+                const referenceCanvas = document.querySelector('#referencePdfContainer canvas');
+                await renderPage(
+                    currentPdfState.referencePdf,
+                    currentPdfState.page,
+                    currentPdfState.scale,
+                    referenceCanvas,
+                    referenceCanvas.getContext('2d')
+                );
+            }
+        }
+
+        function createPdfViewer(id, title) {
+            return `
+                <div class="card">
+                    <div class="p-3 border-b">
+                        <h3 class="font-medium text-purple-900">${title}</h3>
+                    </div>
+                    <div id="${id}" class="pdf-container">
+                        <div class="pdf-controls">
+                            <button onclick="changePage(-1)">◀</button>
+                            <span>Page <input type="number" value="1" min="1" onchange="setPage(this.value)"> of <span class="page-count">0</span></span>
+                            <button onclick="changePage(1)">▶</button>
+                            <button onclick="changeZoom(-0.1)">-</button>
+                            <span>${Math.round(currentPdfState.scale * 100)}%</span>
+                            <button onclick="changeZoom(0.1)">+</button>
+                            <button onclick="fitToWidth()">Fit</button>
+                        </div>
+                        <div class="pdf-canvas-container" onmousedown="startPan(event, this)">
+                            <div class="pdf-canvas-wrapper" onwheel="handleScroll(event, this)">
+                                <canvas class="pdf-canvas"></canvas>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `;
+        }
+
+        // Add scroll synchronization
+        function handleScroll(e, wrapper) {
+            const containers = document.querySelectorAll('.pdf-canvas-wrapper');
+            containers.forEach(container => {
+                if (container !== wrapper) {
+                    container.scrollTop = wrapper.scrollTop;
+                    container.scrollLeft = wrapper.scrollLeft;
+                }
+            });
+        }
+
+        // Add panning functionality
+        let isPanning = false;
+        let startPoint = { x: 0, y: 0 };
+        let scrollPositions = { x: 0, y: 0 };
+        let activePanContainer = null;
+
+        function startPan(e, container) {
+            if (e.button !== 0) return; // Only left mouse button
+            isPanning = true;
+            activePanContainer = container;
+            container.classList.add('panning');
+            
+            startPoint = { x: e.clientX, y: e.clientY };
+            const wrapper = container.querySelector('.pdf-canvas-wrapper');
+            scrollPositions = {
+                x: wrapper.scrollLeft,
+                y: wrapper.scrollTop
+            };
+
+            document.addEventListener('mousemove', handlePan);
+            document.addEventListener('mouseup', endPan);
+            e.preventDefault();
+        }
+
+        function handlePan(e) {
+            if (!isPanning || !activePanContainer) return;
+            
+            const dx = startPoint.x - e.clientX;
+            const dy = startPoint.y - e.clientY;
+
+            const containers = document.querySelectorAll('.pdf-canvas-wrapper');
+            containers.forEach(wrapper => {
+                wrapper.scrollLeft = scrollPositions.x + dx;
+                wrapper.scrollTop = scrollPositions.y + dy;
+            });
+
+            e.preventDefault();
+        }
+
+        function endPan() {
+            if (!isPanning || !activePanContainer) return;
+            
+            isPanning = false;
+            activePanContainer.classList.remove('panning');
+            activePanContainer = null;
+            
+            document.removeEventListener('mousemove', handlePan);
+            document.removeEventListener('mouseup', endPan);
+        }
+
+        async function fitToWidth() {
+            if (!currentPdfState.actualPdf) return;
+
+            const page = await currentPdfState.actualPdf.getPage(currentPdfState.page);
+            const viewport = page.getViewport({ scale: 1.0 });
+            const container = document.querySelector('.pdf-canvas-container');
+            const newScale = (container.clientWidth - 40) / viewport.width;
+            
+            currentPdfState.scale = newScale;
+            document.querySelectorAll('.pdf-controls span:last-of-type').forEach(span => {
+                span.textContent = `${Math.round(newScale * 100)}%`;
+            });
+            await updateBothPdfs();
+        }
+
+        async function showPdfComparison(item) {
             const details = document.getElementById('details');
             
             // Update selected state in sidebar
@@ -129,6 +377,14 @@
             document.getElementById(item.id).classList.add('selected');
             selectedItem = item.id;
 
+            // Reset PDF state
+            currentPdfState = {
+                scale: 1.0,
+                page: 1,
+                actualPdf: null,
+                referencePdf: null
+            };
+
             details.innerHTML = `
                 <div class="card">
                     <div class="p-4 border-b">
@@ -136,22 +392,8 @@
                     </div>
                     <div class="p-4">
                         <div class="grid grid-cols-2 gap-6">
-                            <div class="card">
-                                <div class="p-3 border-b">
-                                    <h3 class="font-medium text-purple-900">Actual PDF</h3>
-                                </div>
-                                <div class="pdf-container">
-                                    <iframe src="/${item.actualPdf}"></iframe>
-                                </div>
-                            </div>
-                            <div class="card">
-                                <div class="p-3 border-b">
-                                    <h3 class="font-medium text-purple-900">Reference PDF</h3>
-                                </div>
-                                <div class="pdf-container">
-                                    <iframe src="/${item.referencePdf}"></iframe>
-                                </div>
-                            </div>
+                            ${createPdfViewer('actualPdfContainer', 'Actual PDF')}
+                            ${createPdfViewer('referencePdfContainer', 'Reference PDF')}
                         </div>
                         ${item.error ? `
                             <div class="mt-6">
@@ -168,6 +410,43 @@
                     </div>
                 </div>
             `;
+
+            // Load both PDFs
+            await Promise.all([
+                loadPdf(item.actualPdf, 'actualPdfContainer'),
+                loadPdf(item.referencePdf, 'referencePdfContainer')
+            ]);
+        }
+
+        async function changePage(delta) {
+            const newPage = currentPdfState.page + delta;
+            if (currentPdfState.actualPdf && newPage >= 1 && newPage <= currentPdfState.actualPdf.numPages) {
+                currentPdfState.page = newPage;
+                document.querySelectorAll('.pdf-controls input[type="number"]').forEach(input => {
+                    input.value = newPage;
+                });
+                await updateBothPdfs();
+            }
+        }
+
+        async function setPage(pageNum) {
+            const newPage = parseInt(pageNum, 10);
+            if (currentPdfState.actualPdf && newPage >= 1 && newPage <= currentPdfState.actualPdf.numPages) {
+                currentPdfState.page = newPage;
+                document.querySelectorAll('.pdf-controls input[type="number"]').forEach(input => {
+                    input.value = newPage;
+                });
+                await updateBothPdfs();
+            }
+        }
+
+        async function changeZoom(delta) {
+            const newScale = Math.max(0.1, Math.min(5.0, currentPdfState.scale + delta));
+            currentPdfState.scale = newScale;
+            document.querySelectorAll('.pdf-controls span:last-of-type').forEach(span => {
+                span.textContent = `${Math.round(newScale * 100)}%`;
+            });
+            await updateBothPdfs();
         }
 
         async function init() {

--- a/test/report/index.html
+++ b/test/report/index.html
@@ -1,202 +1,194 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>jsPDF Test Report</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@radix-ui/themes@2.0.0/styles.css">
-    <script src="test-results.js"></script>
     <style>
-        :root {
-            --background: 0 0% 100%;
-            --foreground: 222.2 84% 4.9%;
-            --muted: 210 40% 96.1%;
-            --muted-foreground: 215.4 16.3% 46.9%;
-            --popover: 0 0% 100%;
-            --popover-foreground: 222.2 84% 4.9%;
-            --card: 0 0% 100%;
-            --card-foreground: 222.2 84% 4.9%;
-            --border: 214.3 31.8% 91.4%;
-            --input: 214.3 31.8% 91.4%;
-            --primary: 222.2 47.4% 11.2%;
-            --primary-foreground: 210 40% 98%;
-            --secondary: 210 40% 96.1%;
-            --secondary-foreground: 222.2 47.4% 11.2%;
-            --accent: 210 40% 96.1%;
-            --accent-foreground: 222.2 47.4% 11.2%;
-            --destructive: 0 84.2% 60.2%;
-            --destructive-foreground: 210 40% 98%;
-            --ring: 215 20.2% 65.1%;
-            --radius: 0.5rem;
-        }
-
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
         body {
-            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
-            background-color: hsl(var(--background));
-            color: hsl(var(--foreground));
+            margin: 0;
+            font-family: system-ui, -apple-system, sans-serif;
         }
-
-        .layout {
+        .container {
             display: grid;
             grid-template-columns: 300px 1fr;
             height: 100vh;
         }
-
         .sidebar {
-            border-right: 1px solid hsl(var(--border));
-            padding: 1rem;
+            background: #f5f5f5;
+            padding: 20px;
+            border-right: 1px solid #ddd;
             overflow-y: auto;
         }
-
         .main {
-            padding: 1rem;
+            padding: 20px;
             overflow-y: auto;
         }
-
-        .test-item {
-            padding: 0.75rem;
-            border: 1px solid hsl(var(--border));
-            border-radius: var(--radius);
-            margin-bottom: 0.5rem;
+        .summary {
+            margin-bottom: 20px;
+            padding: 15px;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        .failure-item {
+            padding: 10px;
+            margin: 5px 0;
+            background: white;
+            border-radius: 4px;
             cursor: pointer;
+            border: 1px solid #ddd;
         }
-
-        .test-item:hover {
-            background-color: hsl(var(--muted));
+        .failure-item:hover {
+            background: #f0f0f0;
         }
-
-        .test-item.failed {
-            border-color: hsl(var(--destructive));
+        .failure-item.selected {
+            background: #e3f2fd;
+            border-color: #2196f3;
         }
-
-        .pdf-viewer {
+        .pdf-view {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pdf-container {
+            border: 1px solid #ddd;
+            padding: 10px;
+            border-radius: 4px;
+        }
+        .pdf-container h3 {
+            margin-top: 0;
+        }
+        iframe {
             width: 100%;
-            height: calc(100vh - 2rem);
-            border: 1px solid hsl(var(--border));
-            border-radius: var(--radius);
-        }
-
-        .viewer-controls {
-            display: flex;
-            gap: 1rem;
-            margin-bottom: 1rem;
-        }
-
-        .button {
-            padding: 0.5rem 1rem;
-            background-color: hsl(var(--primary));
-            color: hsl(var(--primary-foreground));
+            height: 800px;
             border: none;
-            border-radius: var(--radius);
-            cursor: pointer;
         }
-
-        .button:hover {
-            opacity: 0.9;
-        }
-
-        .button.secondary {
-            background-color: hsl(var(--secondary));
-            color: hsl(var(--secondary-foreground));
-        }
-
-        .hex-view {
-            font-family: monospace;
+        .differences {
             white-space: pre-wrap;
-            padding: 1rem;
-            background-color: hsl(var(--muted));
-            border-radius: var(--radius);
+            font-family: monospace;
+            background: #f8f8f8;
+            padding: 10px;
+            border-radius: 4px;
+            margin-top: 20px;
+        }
+        .section {
+            margin-bottom: 30px;
+        }
+        .section h3 {
+            margin-bottom: 10px;
         }
     </style>
 </head>
 <body>
-    <div id="root"></div>
-    <script type="text/babel">
-        function App() {
-            const [selectedTest, setSelectedTest] = React.useState(null);
-            const [viewMode, setViewMode] = React.useState('actual');
-            const [testResults, setTestResults] = React.useState(window.TEST_RESULTS);
+    <div class="container">
+        <div class="sidebar">
+            <div class="summary section">
+                <h2>Test Summary</h2>
+                <div id="summary"></div>
+            </div>
+            <div class="section">
+                <h3>Failed Tests</h3>
+                <div id="failures"></div>
+            </div>
+            <div class="section">
+                <h3>Actual PDFs</h3>
+                <div id="pdfs"></div>
+            </div>
+        </div>
+        <div class="main">
+            <div id="details"></div>
+        </div>
+    </div>
 
-            return (
-                <div className="layout">
-                    <div className="sidebar">
-                        <h2>Test Summary</h2>
-                        <div style={{ margin: '1rem 0' }}>
-                            <div>Total: {testResults.summary.total}</div>
-                            <div style={{ color: 'green' }}>Passed: {testResults.summary.passed}</div>
-                            <div style={{ color: 'orange' }}>Skipped: {testResults.summary.skipped}</div>
-                            <div style={{ color: 'red' }}>Failed: {testResults.summary.failed}</div>
-                        </div>
-                        <h3>Failed Tests</h3>
-                        {testResults.failures.map((test, index) => (
-                            <div 
-                                key={index}
-                                className="test-item failed"
-                                onClick={() => setSelectedTest(test)}
-                            >
-                                <div>{test.name}</div>
-                                <div style={{ fontSize: '0.875rem', color: 'hsl(var(--muted-foreground))' }}>
-                                    {test.differences.total} differences
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                    <div className="main">
-                        {selectedTest ? (
-                            <>
-                                <div className="viewer-controls">
-                                    <button 
-                                        className={`button ${viewMode === 'actual' ? '' : 'secondary'}`}
-                                        onClick={() => setViewMode('actual')}
-                                    >
-                                        Actual
-                                    </button>
-                                    <button 
-                                        className={`button ${viewMode === 'reference' ? '' : 'secondary'}`}
-                                        onClick={() => setViewMode('reference')}
-                                    >
-                                        Reference
-                                    </button>
-                                    <button 
-                                        className={`button ${viewMode === 'hex' ? '' : 'secondary'}`}
-                                        onClick={() => setViewMode('hex')}
-                                    >
-                                        Hex Diff
-                                    </button>
-                                </div>
-                                {viewMode === 'hex' ? (
-                                    <div className="hex-view">
-                                        {/* Placeholder for hex diff */}
-                                        Hex diff view coming soon...
-                                    </div>
-                                ) : (
-                                    <iframe 
-                                        className="pdf-viewer"
-                                        src={viewMode === 'actual' ? selectedTest.actualPdf : selectedTest.referencePdf}
-                                    />
-                                )}
-                            </>
-                        ) : (
-                            <div style={{ padding: '2rem', textAlign: 'center' }}>
-                                Select a test from the sidebar to view details
-                            </div>
-                        )}
-                    </div>
-                </div>
-            );
+    <!-- Load test results -->
+    <script src="test-results.js"></script>
+
+    <script>
+        let selectedItem = null;
+
+        function formatSummary(results) {
+            return `
+                <div>Total: ${results.total}</div>
+                <div style="color: #4caf50">Passed: ${results.passed}</div>
+                <div style="color: #f44336">Failed: ${results.failed}</div>
+                <div style="color: #ff9800">Skipped: ${results.skipped}</div>
+            `;
         }
 
-        const root = ReactDOM.createRoot(document.getElementById('root'));
-        root.render(<App />);
+        function showPdfComparison(item) {
+            const details = document.getElementById('details');
+            
+            // Update selected state in sidebar
+            if (selectedItem) {
+                document.getElementById(selectedItem).classList.remove('selected');
+            }
+            document.getElementById(item.id).classList.add('selected');
+            selectedItem = item.id;
+
+            details.innerHTML = `
+                <h2>${item.name}</h2>
+                <div class="pdf-view">
+                    <div class="pdf-container">
+                        <h3>Actual PDF</h3>
+                        <iframe src="/${item.actualPdf}"></iframe>
+                    </div>
+                    <div class="pdf-container">
+                        <h3>Reference PDF</h3>
+                        <iframe src="/${item.referencePdf}"></iframe>
+                    </div>
+                </div>
+                ${item.error ? `
+                    <div class="differences">
+                        <h3>Differences</h3>
+                        <pre>${item.error}</pre>
+                    </div>
+                ` : ''}
+            `;
+        }
+
+        async function init() {
+            const results = window.TEST_RESULTS;
+
+            // Update summary
+            document.getElementById('summary').innerHTML = formatSummary(results);
+
+            // Update failures list
+            const failures = results.failures || [];
+            const failuresHtml = failures.map(failure => `
+                <div id="failure_${failure.name.replace(/[^a-zA-Z0-9]/g, '_')}" class="failure-item" onclick='showPdfComparison(${JSON.stringify({...failure, id: "failure_" + failure.name.replace(/[^a-zA-Z0-9]/g, '_')}).replace(/'/g, "&#39;")})'>
+                    ${failure.name}
+                </div>
+            `).join('');
+            document.getElementById('failures').innerHTML = failuresHtml || '<div class="failure-item">No failures</div>';
+
+            // Load and display actual PDFs
+            try {
+                const response = await fetch('/api/pdfs');
+                const pdfs = await response.json();
+                const pdfsHtml = pdfs.map(pdf => `
+                    <div id="pdf_${pdf.name.replace(/[^a-zA-Z0-9]/g, '_')}" class="failure-item" onclick='showPdfComparison(${JSON.stringify({...pdf, id: "pdf_" + pdf.name.replace(/[^a-zA-Z0-9]/g, '_')}).replace(/'/g, "&#39;")})'>
+                        ${pdf.name}
+                    </div>
+                `).join('');
+                document.getElementById('pdfs').innerHTML = pdfsHtml || '<div class="failure-item">No PDFs found</div>';
+
+                // Show first failure by default, or first PDF if no failures
+                if (failures.length > 0) {
+                    showPdfComparison({...failures[0], id: "failure_" + failures[0].name.replace(/[^a-zA-Z0-9]/g, '_')});
+                } else if (pdfs.length > 0) {
+                    showPdfComparison({...pdfs[0], id: "pdf_" + pdfs[0].name.replace(/[^a-zA-Z0-9]/g, '_')});
+                }
+            } catch (error) {
+                console.error('Failed to load PDFs:', error);
+                document.getElementById('pdfs').innerHTML = `
+                    <div class="failure-item">
+                        Failed to load PDFs: ${error.message}
+                    </div>
+                `;
+            }
+        }
+
+        init();
     </script>
 </body>
 </html> 

--- a/test/report/index.html
+++ b/test/report/index.html
@@ -213,7 +213,7 @@
                 currentPdfState.scale = initialScale;
 
                 // Update zoom display
-                document.querySelectorAll('.pdf-controls span:last-of-type').forEach(span => {
+                document.querySelectorAll('.pdf-controls .zoom-level').forEach(span => {
                     span.textContent = `${Math.round(initialScale * 100)}%`;
                 });
 
@@ -277,7 +277,7 @@
                             <span>Page <input type="number" value="1" min="1" onchange="setPage(this.value)"> of <span class="page-count">0</span></span>
                             <button onclick="changePage(1)">▶</button>
                             <button onclick="changeZoom(-0.1)">-</button>
-                            <span>${Math.round(currentPdfState.scale * 100)}%</span>
+                            <span class="zoom-level">${Math.round(currentPdfState.scale * 100)}%</span>
                             <button onclick="changeZoom(0.1)">+</button>
                             <button onclick="fitToWidth()">Fit</button>
                         </div>
@@ -361,7 +361,7 @@
             const newScale = (container.clientWidth - 40) / viewport.width;
             
             currentPdfState.scale = newScale;
-            document.querySelectorAll('.pdf-controls span:last-of-type').forEach(span => {
+            document.querySelectorAll('.pdf-controls .zoom-level').forEach(span => {
                 span.textContent = `${Math.round(newScale * 100)}%`;
             });
             await updateBothPdfs();
@@ -443,7 +443,7 @@
         async function changeZoom(delta) {
             const newScale = Math.max(0.1, Math.min(5.0, currentPdfState.scale + delta));
             currentPdfState.scale = newScale;
-            document.querySelectorAll('.pdf-controls span:last-of-type').forEach(span => {
+            document.querySelectorAll('.pdf-controls .zoom-level').forEach(span => {
                 span.textContent = `${Math.round(newScale * 100)}%`;
             });
             await updateBothPdfs();

--- a/test/report/index.html
+++ b/test/report/index.html
@@ -2,63 +2,10 @@
 <html>
 <head>
     <title>jsPDF Test Report</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <style>
-        body {
-            margin: 0;
-            font-family: system-ui, -apple-system, sans-serif;
-        }
-        .container {
-            display: grid;
-            grid-template-columns: 300px 1fr;
-            height: 100vh;
-        }
-        .sidebar {
-            background: #f5f5f5;
-            padding: 20px;
-            border-right: 1px solid #ddd;
-            overflow-y: auto;
-        }
-        .main {
-            padding: 20px;
-            overflow-y: auto;
-        }
-        .summary {
-            margin-bottom: 20px;
-            padding: 15px;
-            background: white;
-            border-radius: 8px;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-        }
-        .failure-item {
-            padding: 10px;
-            margin: 5px 0;
-            background: white;
-            border-radius: 4px;
-            cursor: pointer;
-            border: 1px solid #ddd;
-        }
-        .failure-item:hover {
-            background: #f0f0f0;
-        }
-        .failure-item.selected {
-            background: #e3f2fd;
-            border-color: #2196f3;
-        }
-        .pdf-view {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 20px;
-            margin-top: 20px;
-        }
-        .pdf-container {
-            border: 1px solid #ddd;
-            padding: 10px;
-            border-radius: 4px;
-        }
-        .pdf-container h3 {
-            margin-top: 0;
-        }
-        iframe {
+        /* Preserve existing styles that are still needed */
+        .pdf-container iframe {
             width: 100%;
             height: 800px;
             border: none;
@@ -66,37 +13,86 @@
         .differences {
             white-space: pre-wrap;
             font-family: monospace;
-            background: #f8f8f8;
-            padding: 10px;
-            border-radius: 4px;
-            margin-top: 20px;
         }
-        .section {
-            margin-bottom: 30px;
+        /* New styles for Shadcn-like look with purple theme */
+        .sidebar {
+            background-color: hsl(0 0% 100%);
+            border-right: 1px solid hsl(240 6% 90%);
         }
-        .section h3 {
-            margin-bottom: 10px;
+        .main {
+            background-color: hsl(240 3.7% 97.5%);
+        }
+        .card {
+            background-color: hsl(0 0% 100%);
+            border: 1px solid hsl(240 6% 90%);
+            border-radius: 0.5rem;
+            box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+        }
+        .nav-item {
+            padding: 0.5rem;
+            margin: 0.25rem 0;
+            border-radius: 0.375rem;
+            cursor: pointer;
+            transition: background-color 0.2s;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        .nav-item:hover {
+            background-color: hsl(240 5% 96%);
+        }
+        .nav-item.selected {
+            background-color: hsl(244.9 40% 97%);
+            color: hsl(244.9 40% 40%);
+            font-weight: 500;
+        }
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            border-radius: 9999px;
+            padding: 0.125rem 0.5rem;
+            font-size: 0.75rem;
+            font-weight: 500;
+            line-height: 1;
+            white-space: nowrap;
+        }
+        .badge-success { background-color: hsl(142.1 76.2% 36.3% / 0.1); color: hsl(142.1 76.2% 36.3%); }
+        .badge-error { background-color: hsl(346.8 77.2% 49.8% / 0.1); color: hsl(346.8 77.2% 49.8%); }
+        .badge-warning { background-color: hsl(48 96.5% 53.8% / 0.1); color: hsl(48 96.5% 53.8%); }
+        .icon {
+            width: 1rem;
+            height: 1rem;
         }
     </style>
 </head>
-<body>
-    <div class="container">
-        <div class="sidebar">
-            <div class="summary section">
-                <h2>Test Summary</h2>
-                <div id="summary"></div>
-            </div>
-            <div class="section">
-                <h3>Failed Tests</h3>
-                <div id="failures"></div>
-            </div>
-            <div class="section">
-                <h3>Actual PDFs</h3>
-                <div id="pdfs"></div>
+<body class="antialiased">
+    <div class="flex h-screen">
+        <!-- Sidebar -->
+        <div class="w-80 flex flex-col sidebar overflow-y-auto p-4">
+            <div class="space-y-4">
+                <!-- Summary Card -->
+                <div class="card p-4">
+                    <h2 class="text-lg font-semibold mb-3 text-purple-900">Test Summary</h2>
+                    <div id="summary" class="space-y-2"></div>
+                </div>
+
+                <!-- Failed Tests -->
+                <div class="space-y-2">
+                    <h3 class="text-sm font-medium text-purple-900">Failed Tests</h3>
+                    <div id="failures" class="space-y-1"></div>
+                </div>
+
+                <!-- Actual PDFs -->
+                <div class="space-y-2">
+                    <h3 class="text-sm font-medium text-purple-900">Actual PDFs</h3>
+                    <div id="pdfs" class="space-y-1"></div>
+                </div>
             </div>
         </div>
-        <div class="main">
-            <div id="details"></div>
+
+        <!-- Main Content -->
+        <div class="flex-1 main overflow-y-auto p-6">
+            <div id="details" class="max-w-6xl mx-auto"></div>
         </div>
     </div>
 
@@ -106,12 +102,26 @@
     <script>
         let selectedItem = null;
 
+        const documentIcon = `<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><line x1="10" y1="9" x2="8" y2="9"></line></svg>`;
+
         function formatSummary(results) {
             return `
-                <div>Total: ${results.total}</div>
-                <div style="color: #4caf50">Passed: ${results.passed}</div>
-                <div style="color: #f44336">Failed: ${results.failed}</div>
-                <div style="color: #ff9800">Skipped: ${results.skipped}</div>
+                <div class="flex items-center justify-between">
+                    <span class="text-sm">Total</span>
+                    <span class="badge bg-purple-100 text-purple-800">${results.total}</span>
+                </div>
+                <div class="flex items-center justify-between">
+                    <span class="text-sm">Passed</span>
+                    <span class="badge badge-success">${results.passed}</span>
+                </div>
+                <div class="flex items-center justify-between">
+                    <span class="text-sm">Failed</span>
+                    <span class="badge badge-error">${results.failed}</span>
+                </div>
+                <div class="flex items-center justify-between">
+                    <span class="text-sm">Skipped</span>
+                    <span class="badge badge-warning">${results.skipped}</span>
+                </div>
             `;
         }
 
@@ -126,23 +136,43 @@
             selectedItem = item.id;
 
             details.innerHTML = `
-                <h2>${item.name}</h2>
-                <div class="pdf-view">
-                    <div class="pdf-container">
-                        <h3>Actual PDF</h3>
-                        <iframe src="/${item.actualPdf}"></iframe>
+                <div class="card">
+                    <div class="p-4 border-b">
+                        <h2 class="text-lg font-semibold text-purple-900">${item.name}</h2>
                     </div>
-                    <div class="pdf-container">
-                        <h3>Reference PDF</h3>
-                        <iframe src="/${item.referencePdf}"></iframe>
+                    <div class="p-4">
+                        <div class="grid grid-cols-2 gap-6">
+                            <div class="card">
+                                <div class="p-3 border-b">
+                                    <h3 class="font-medium text-purple-900">Actual PDF</h3>
+                                </div>
+                                <div class="pdf-container">
+                                    <iframe src="/${item.actualPdf}"></iframe>
+                                </div>
+                            </div>
+                            <div class="card">
+                                <div class="p-3 border-b">
+                                    <h3 class="font-medium text-purple-900">Reference PDF</h3>
+                                </div>
+                                <div class="pdf-container">
+                                    <iframe src="/${item.referencePdf}"></iframe>
+                                </div>
+                            </div>
+                        </div>
+                        ${item.error ? `
+                            <div class="mt-6">
+                                <div class="card">
+                                    <div class="p-3 border-b">
+                                        <h3 class="font-medium text-purple-900">Differences</h3>
+                                    </div>
+                                    <div class="p-4 bg-purple-50 differences">
+                                        <pre class="text-sm">${item.error}</pre>
+                                    </div>
+                                </div>
+                            </div>
+                        ` : ''}
                     </div>
                 </div>
-                ${item.error ? `
-                    <div class="differences">
-                        <h3>Differences</h3>
-                        <pre>${item.error}</pre>
-                    </div>
-                ` : ''}
             `;
         }
 
@@ -155,22 +185,28 @@
             // Update failures list
             const failures = results.failures || [];
             const failuresHtml = failures.map(failure => `
-                <div id="failure_${failure.name.replace(/[^a-zA-Z0-9]/g, '_')}" class="failure-item" onclick='showPdfComparison(${JSON.stringify({...failure, id: "failure_" + failure.name.replace(/[^a-zA-Z0-9]/g, '_')}).replace(/'/g, "&#39;")})'>
+                <div id="failure_${failure.name.replace(/[^a-zA-Z0-9]/g, '_')}" 
+                     class="nav-item text-sm" 
+                     onclick='showPdfComparison(${JSON.stringify({...failure, id: "failure_" + failure.name.replace(/[^a-zA-Z0-9]/g, '_')}).replace(/'/g, "&#39;")})'>
+                    ${documentIcon}
                     ${failure.name}
                 </div>
             `).join('');
-            document.getElementById('failures').innerHTML = failuresHtml || '<div class="failure-item">No failures</div>';
+            document.getElementById('failures').innerHTML = failuresHtml || '<div class="nav-item text-sm text-gray-500">No failures</div>';
 
             // Load and display actual PDFs
             try {
                 const response = await fetch('/api/pdfs');
                 const pdfs = await response.json();
                 const pdfsHtml = pdfs.map(pdf => `
-                    <div id="pdf_${pdf.name.replace(/[^a-zA-Z0-9]/g, '_')}" class="failure-item" onclick='showPdfComparison(${JSON.stringify({...pdf, id: "pdf_" + pdf.name.replace(/[^a-zA-Z0-9]/g, '_')}).replace(/'/g, "&#39;")})'>
+                    <div id="pdf_${pdf.name.replace(/[^a-zA-Z0-9]/g, '_')}" 
+                         class="nav-item text-sm"
+                         onclick='showPdfComparison(${JSON.stringify({...pdf, id: "pdf_" + pdf.name.replace(/[^a-zA-Z0-9]/g, '_')}).replace(/'/g, "&#39;")})'>
+                        ${documentIcon}
                         ${pdf.name}
                     </div>
                 `).join('');
-                document.getElementById('pdfs').innerHTML = pdfsHtml || '<div class="failure-item">No PDFs found</div>';
+                document.getElementById('pdfs').innerHTML = pdfsHtml || '<div class="nav-item text-sm text-gray-500">No PDFs found</div>';
 
                 // Show first failure by default, or first PDF if no failures
                 if (failures.length > 0) {
@@ -181,7 +217,7 @@
             } catch (error) {
                 console.error('Failed to load PDFs:', error);
                 document.getElementById('pdfs').innerHTML = `
-                    <div class="failure-item">
+                    <div class="nav-item text-sm text-red-500">
                         Failed to load PDFs: ${error.message}
                     </div>
                 `;

--- a/test/report/index.html
+++ b/test/report/index.html
@@ -298,10 +298,17 @@
                 // Store PDF reference
                 if (containerId === 'actualPdfContainer') {
                     currentPdfState.actualPdf = pdf;
-                    // Update page count in consolidated controls
-                    document.querySelector('.consolidated-controls .page-count').textContent = pdf.numPages;
+                    // Update page count in consolidated controls if reference PDF isn't loaded yet
+                    // or if actual PDF has fewer pages
+                    if (!currentPdfState.referencePdf || pdf.numPages < currentPdfState.referencePdf.numPages) {
+                        document.querySelector('.consolidated-controls .page-count').textContent = pdf.numPages;
+                    }
                 } else {
                     currentPdfState.referencePdf = pdf;
+                    // Update page count if reference PDF has more pages than actual PDF
+                    if (!currentPdfState.actualPdf || pdf.numPages > currentPdfState.actualPdf.numPages) {
+                        document.querySelector('.consolidated-controls .page-count').textContent = pdf.numPages;
+                    }
                 }
 
                 // Calculate initial scale to fit width

--- a/test/report/index.html
+++ b/test/report/index.html
@@ -76,15 +76,9 @@
                     <div id="summary" class="space-y-2"></div>
                 </div>
 
-                <!-- Failed Tests -->
+                <!-- Failing PDFs -->
                 <div class="space-y-2">
-                    <h3 class="text-sm font-medium text-purple-900">Failed Tests</h3>
-                    <div id="failures" class="space-y-1"></div>
-                </div>
-
-                <!-- Actual PDFs -->
-                <div class="space-y-2">
-                    <h3 class="text-sm font-medium text-purple-900">Actual PDFs</h3>
+                    <h3 class="text-sm font-medium text-purple-900">Failing PDFs</h3>
                     <div id="pdfs" class="space-y-1"></div>
                 </div>
             </div>
@@ -182,19 +176,7 @@
             // Update summary
             document.getElementById('summary').innerHTML = formatSummary(results);
 
-            // Update failures list
-            const failures = results.failures || [];
-            const failuresHtml = failures.map(failure => `
-                <div id="failure_${failure.name.replace(/[^a-zA-Z0-9]/g, '_')}" 
-                     class="nav-item text-sm" 
-                     onclick='showPdfComparison(${JSON.stringify({...failure, id: "failure_" + failure.name.replace(/[^a-zA-Z0-9]/g, '_')}).replace(/'/g, "&#39;")})'>
-                    ${documentIcon}
-                    ${failure.name}
-                </div>
-            `).join('');
-            document.getElementById('failures').innerHTML = failuresHtml || '<div class="nav-item text-sm text-gray-500">No failures</div>';
-
-            // Load and display actual PDFs
+            // Load and display failing PDFs
             try {
                 const response = await fetch('/api/pdfs');
                 const pdfs = await response.json();
@@ -206,12 +188,10 @@
                         ${pdf.name}
                     </div>
                 `).join('');
-                document.getElementById('pdfs').innerHTML = pdfsHtml || '<div class="nav-item text-sm text-gray-500">No PDFs found</div>';
+                document.getElementById('pdfs').innerHTML = pdfsHtml || '<div class="nav-item text-sm text-gray-500">No failing PDFs</div>';
 
-                // Show first failure by default, or first PDF if no failures
-                if (failures.length > 0) {
-                    showPdfComparison({...failures[0], id: "failure_" + failures[0].name.replace(/[^a-zA-Z0-9]/g, '_')});
-                } else if (pdfs.length > 0) {
+                // Show first PDF if available
+                if (pdfs.length > 0) {
                     showPdfComparison({...pdfs[0], id: "pdf_" + pdfs[0].name.replace(/[^a-zA-Z0-9]/g, '_')});
                 }
             } catch (error) {

--- a/test/report/index.html
+++ b/test/report/index.html
@@ -8,7 +8,7 @@
         /* Preserve existing styles that are still needed */
         .pdf-container {
             width: 100%;
-            height: 800px;
+            height: 600px;
             position: relative;
             overflow: hidden;
             background: #525659;
@@ -122,6 +122,107 @@
             color: white;
             text-align: center;
         }
+        /* New styles for consolidated controls and hex diff */
+        .consolidated-controls {
+            padding: 0.75rem;
+            background: #2D3748;
+            display: flex;
+            gap: 1rem;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+            position: sticky;
+            top: 0;
+            z-index: 10;
+        }
+        .consolidated-controls button {
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            background: rgba(255, 255, 255, 0.2);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            color: white;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+        .consolidated-controls button:hover {
+            background: rgba(255, 255, 255, 0.3);
+        }
+        .consolidated-controls input {
+            width: 4rem;
+            padding: 0.25rem;
+            border-radius: 0.25rem;
+            background: rgba(255, 255, 255, 0.1);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            color: white;
+            text-align: center;
+        }
+        .hex-diff {
+            background: #1A202C;
+            color: #E2E8F0;
+            font-family: monospace;
+            padding: 1rem;
+            overflow: auto;
+            height: 200px;
+            font-size: 0.875rem;
+            line-height: 1.5;
+            border-radius: 0.5rem;
+            margin-top: 1rem;
+        }
+        .hex-diff-header {
+            position: sticky;
+            top: 0;
+            background: #2D3748;
+            padding: 0.5rem;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .hex-diff-content {
+            display: grid;
+            grid-template-columns: auto 1fr 1fr;
+            gap: 2rem;
+            padding: 0.5rem;
+        }
+        .hex-diff-line {
+            display: contents;
+        }
+        .hex-diff-line > div {
+            padding: 0.125rem 0.5rem;
+        }
+        .hex-diff-line.different {
+            background: rgba(239, 68, 68, 0.1);
+            color: #F87171;
+        }
+        .hex-diff-offset {
+            color: #9CA3AF;
+        }
+        .diff-section {
+            margin-top: 1.5rem;
+            background: white;
+            border-radius: 0.5rem;
+            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            overflow: hidden;
+        }
+        .diff-section-header {
+            padding: 0.75rem 1rem;
+            background: #F8FAFC;
+            border-bottom: 1px solid #E2E8F0;
+            font-weight: 500;
+            color: #1A202C;
+        }
+        .pdf-viewers {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 1.5rem;
+        }
+        .pdf-comparison {
+            background: white;
+            border-radius: 0.5rem;
+            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            overflow: hidden;
+        }
     </style>
 </head>
 <body class="antialiased">
@@ -197,13 +298,11 @@
                 // Store PDF reference
                 if (containerId === 'actualPdfContainer') {
                     currentPdfState.actualPdf = pdf;
+                    // Update page count in consolidated controls
+                    document.querySelector('.consolidated-controls .page-count').textContent = pdf.numPages;
                 } else {
                     currentPdfState.referencePdf = pdf;
                 }
-
-                // Update page count in controls
-                const pageCount = pdf.numPages;
-                container.querySelector('.page-count').textContent = pageCount;
 
                 // Calculate initial scale to fit width
                 const page = await pdf.getPage(1);
@@ -213,11 +312,9 @@
                 currentPdfState.scale = initialScale;
 
                 // Update zoom display
-                document.querySelectorAll('.pdf-controls .zoom-level').forEach(span => {
-                    span.textContent = `${Math.round(initialScale * 100)}%`;
-                });
+                document.querySelector('.consolidated-controls .zoom-level').textContent = `${Math.round(initialScale * 100)}%`;
 
-                // Render current page
+                // Render first page immediately
                 await renderPage(pdf, currentPdfState.page, currentPdfState.scale, canvas, context);
 
                 return pdf;
@@ -272,15 +369,6 @@
                         <h3 class="font-medium text-purple-900">${title}</h3>
                     </div>
                     <div id="${id}" class="pdf-container">
-                        <div class="pdf-controls">
-                            <button onclick="changePage(-1)">◀</button>
-                            <span>Page <input type="number" value="1" min="1" onchange="setPage(this.value)"> of <span class="page-count">0</span></span>
-                            <button onclick="changePage(1)">▶</button>
-                            <button onclick="changeZoom(-0.1)">-</button>
-                            <span class="zoom-level">${Math.round(currentPdfState.scale * 100)}%</span>
-                            <button onclick="changeZoom(0.1)">+</button>
-                            <button onclick="fitToWidth()">Fit</button>
-                        </div>
                         <div class="pdf-canvas-container" onmousedown="startPan(event, this)">
                             <div class="pdf-canvas-wrapper" onwheel="handleScroll(event, this)">
                                 <canvas class="pdf-canvas"></canvas>
@@ -386,24 +474,46 @@
             };
 
             details.innerHTML = `
-                <div class="card">
+                <div class="pdf-comparison">
                     <div class="p-4 border-b">
                         <h2 class="text-lg font-semibold text-purple-900">${item.name}</h2>
                     </div>
+                    
+                    <div class="consolidated-controls">
+                        <button onclick="changePage(-1)">◀</button>
+                        <span>Page <input type="number" value="1" min="1" onchange="setPage(this.value)"> of <span class="page-count">0</span></span>
+                        <button onclick="changePage(1)">▶</button>
+                        <div class="border-l border-gray-600 mx-2 h-6"></div>
+                        <button onclick="changeZoom(-0.1)">-</button>
+                        <span class="zoom-level">${Math.round(currentPdfState.scale * 100)}%</span>
+                        <button onclick="changeZoom(0.1)">+</button>
+                        <button onclick="fitToWidth()">Fit</button>
+                    </div>
+
                     <div class="p-4">
-                        <div class="grid grid-cols-2 gap-6">
+                        <div class="pdf-viewers">
                             ${createPdfViewer('actualPdfContainer', 'Actual PDF')}
                             ${createPdfViewer('referencePdfContainer', 'Reference PDF')}
                         </div>
+
+                        <div class="diff-section">
+                            <div class="diff-section-header">
+                                Binary Differences
+                            </div>
+                            <div class="hex-diff">
+                                <div class="hex-diff-content" id="hexDiffContent">
+                                    <!-- Hex diff content will be populated here -->
+                                </div>
+                            </div>
+                        </div>
+
                         ${item.error ? `
-                            <div class="mt-6">
-                                <div class="card">
-                                    <div class="p-3 border-b">
-                                        <h3 class="font-medium text-purple-900">Differences</h3>
-                                    </div>
-                                    <div class="p-4 bg-purple-50 differences">
-                                        <pre class="text-sm">${item.error}</pre>
-                                    </div>
+                            <div class="diff-section">
+                                <div class="diff-section-header">
+                                    PDF Comparison Results
+                                </div>
+                                <div class="p-4 bg-purple-50 differences">
+                                    <pre class="text-sm">${item.error}</pre>
                                 </div>
                             </div>
                         ` : ''}
@@ -416,15 +526,31 @@
                 loadPdf(item.actualPdf, 'actualPdfContainer'),
                 loadPdf(item.referencePdf, 'referencePdfContainer')
             ]);
+
+            // Simulate hex diff (replace with actual implementation)
+            const hexDiffContent = document.getElementById('hexDiffContent');
+            if (hexDiffContent) {
+                // This is a placeholder - replace with actual hex diff implementation
+                hexDiffContent.innerHTML = `
+                    <div class="hex-diff-line">
+                        <div class="hex-diff-offset">0000</div>
+                        <div>25 50 44 46</div>
+                        <div>25 50 44 46</div>
+                    </div>
+                    <div class="hex-diff-line different">
+                        <div class="hex-diff-offset">0010</div>
+                        <div>2D 31 2E 37</div>
+                        <div>2D 31 2E 36</div>
+                    </div>
+                `;
+            }
         }
 
         async function changePage(delta) {
             const newPage = currentPdfState.page + delta;
             if (currentPdfState.actualPdf && newPage >= 1 && newPage <= currentPdfState.actualPdf.numPages) {
                 currentPdfState.page = newPage;
-                document.querySelectorAll('.pdf-controls input[type="number"]').forEach(input => {
-                    input.value = newPage;
-                });
+                document.querySelector('.consolidated-controls input[type="number"]').value = newPage;
                 await updateBothPdfs();
             }
         }
@@ -433,9 +559,7 @@
             const newPage = parseInt(pageNum, 10);
             if (currentPdfState.actualPdf && newPage >= 1 && newPage <= currentPdfState.actualPdf.numPages) {
                 currentPdfState.page = newPage;
-                document.querySelectorAll('.pdf-controls input[type="number"]').forEach(input => {
-                    input.value = newPage;
-                });
+                document.querySelector('.consolidated-controls input[type="number"]').value = newPage;
                 await updateBothPdfs();
             }
         }
@@ -443,9 +567,7 @@
         async function changeZoom(delta) {
             const newScale = Math.max(0.1, Math.min(5.0, currentPdfState.scale + delta));
             currentPdfState.scale = newScale;
-            document.querySelectorAll('.pdf-controls .zoom-level').forEach(span => {
-                span.textContent = `${Math.round(newScale * 100)}%`;
-            });
+            document.querySelector('.consolidated-controls .zoom-level').textContent = `${Math.round(newScale * 100)}%`;
             await updateBothPdfs();
         }
 

--- a/test/report/index.html
+++ b/test/report/index.html
@@ -496,27 +496,14 @@
                             ${createPdfViewer('referencePdfContainer', 'Reference PDF')}
                         </div>
 
-                        <div class="diff-section">
+                        <div class="diff-section mt-4">
                             <div class="diff-section-header">
-                                Binary Differences
+                                PDF Comparison Results
                             </div>
-                            <div class="hex-diff">
-                                <div class="hex-diff-content" id="hexDiffContent">
-                                    <!-- Hex diff content will be populated here -->
-                                </div>
+                            <div class="p-4 bg-purple-50">
+                                <pre id="pdfComparisonResults" class="text-sm font-mono whitespace-pre-wrap"></pre>
                             </div>
                         </div>
-
-                        ${item.error ? `
-                            <div class="diff-section">
-                                <div class="diff-section-header">
-                                    PDF Comparison Results
-                                </div>
-                                <div class="p-4 bg-purple-50 differences">
-                                    <pre class="text-sm">${item.error}</pre>
-                                </div>
-                            </div>
-                        ` : ''}
                     </div>
                 </div>
             `;
@@ -527,22 +514,31 @@
                 loadPdf(item.referencePdf, 'referencePdfContainer')
             ]);
 
-            // Simulate hex diff (replace with actual implementation)
-            const hexDiffContent = document.getElementById('hexDiffContent');
-            if (hexDiffContent) {
-                // This is a placeholder - replace with actual hex diff implementation
-                hexDiffContent.innerHTML = `
-                    <div class="hex-diff-line">
-                        <div class="hex-diff-offset">0000</div>
-                        <div>25 50 44 46</div>
-                        <div>25 50 44 46</div>
-                    </div>
-                    <div class="hex-diff-line different">
-                        <div class="hex-diff-offset">0010</div>
-                        <div>2D 31 2E 37</div>
-                        <div>2D 31 2E 36</div>
-                    </div>
-                `;
+            // Display PDF comparison results
+            const comparisonResults = document.getElementById('pdfComparisonResults');
+            if (comparisonResults) {
+                try {
+                    const response = await fetch('/api/compare', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({
+                            actualPath: item.actualPdf,
+                            referencePath: item.referencePdf
+                        })
+                    });
+                    
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+                    
+                    const result = await response.text();
+                    comparisonResults.textContent = result || 'No differences found between PDFs';
+                } catch (error) {
+                    comparisonResults.textContent = `Error comparing PDFs: ${error.message}`;
+                    console.error('Comparison error:', error);
+                }
             }
         }
 

--- a/test/report/server.js
+++ b/test/report/server.js
@@ -1,33 +1,110 @@
 const express = require('express');
 const path = require('path');
 const fs = require('fs');
-
 const app = express();
 
-// Serve static files from the report directory
-app.use(express.static(path.join(__dirname)));
+// Set up the global environment needed by compare.js
+global.isNode = true;
 
+// Mock the test framework functions to capture the comparison output
+let comparisonOutput = '';
+global.fail = function(msg) { 
+    // Extract just the comparison results, removing the raw PDF content
+    comparisonOutput = msg.split('Actual PDF saved to:')[0].trim();
+    throw new Error(msg);
+};
+global.expect = function(actual) {
+    return {
+        toEqual: function(expected) {
+            if (actual !== expected) {
+                const msg = `Expected ${expected} but got ${actual}`;
+                comparisonOutput = msg;
+                throw new Error(msg);
+            }
+        }
+    };
+};
+
+// Load the comparison module
+const comparePath = path.join(__dirname, '../utils/compare.js');
+require(comparePath);
+
+app.use(express.json());
+// Serve static files from the report directory
+app.use(express.static(__dirname));
 // Serve PDFs from test directory
 app.use('/test', express.static(path.join(__dirname, '..')));
 
 // API endpoint to list actual PDFs
 app.get('/api/pdfs', (req, res) => {
-  const actualDir = path.join(__dirname, '../actual');
-  try {
-    const files = fs.readdirSync(actualDir)
-      .filter(file => file.endsWith('.pdf'))
-      .map(file => ({
-        name: file,
-        actualPdf: `test/actual/${file}`,
-        referencePdf: `test/reference/${file}`
-      }));
-    res.json(files);
-  } catch (err) {
-    res.status(500).json({ error: err.message });
-  }
+    const actualDir = path.join(__dirname, '../actual');
+    try {
+        const files = fs.readdirSync(actualDir)
+            .filter(file => file.endsWith('.pdf'))
+            .map(file => ({
+                name: file,
+                actualPdf: `test/actual/${file}`,
+                referencePdf: `test/reference/${file}`
+            }));
+        res.json(files);
+    } catch (err) {
+        res.status(500).json({ error: err.message });
+    }
 });
 
-const port = 3000;
-app.listen(port, () => {
-  console.log(`Test report server running at http://localhost:${port}`);
+app.post('/api/compare', (req, res) => {
+    const { actualPath, referencePath } = req.body;
+    
+    if (!actualPath || !referencePath) {
+        return res.status(400).send('Missing required paths');
+    }
+
+    // Construct absolute paths
+    const rootDir = path.join(__dirname, '../..');
+    const actualAbsPath = path.join(rootDir, actualPath);
+    const referenceAbsPath = path.join(rootDir, referencePath);
+    
+    // Verify files exist
+    if (!fs.existsSync(actualAbsPath)) {
+        return res.status(404).send(`Actual PDF not found: ${actualPath}`);
+    }
+    if (!fs.existsSync(referenceAbsPath)) {
+        return res.status(404).send(`Reference PDF not found: ${referencePath}`);
+    }
+
+    try {
+        // Reset the comparison output
+        comparisonOutput = '';
+
+        // Log absolute paths
+        console.log('Absolute paths:');
+        console.log('Actual:', actualAbsPath);
+        console.log('Reference:', referenceAbsPath);
+
+        // Read the actual PDF
+        const actualPdf = fs.readFileSync(actualAbsPath, 'latin1');
+        console.log('Actual PDF size:', actualPdf.length);
+        console.log('Actual starts with:', actualPdf.substring(0, 20));
+
+        // Extract the filename from the reference path
+        const referenceFilename = path.basename(referencePath);
+        console.log('Reference filename:', referenceFilename);
+
+        try {
+            // Use the comparePdf function with the correct signature
+            global.comparePdf(actualPdf, referenceFilename);
+            res.send('No differences found between PDFs');
+        } catch (compareError) {
+            // Send the captured comparison output
+            res.send(comparisonOutput);
+        }
+    } catch (error) {
+        console.error('Comparison error:', error);
+        res.status(500).send(`Error comparing PDFs: ${error.message}`);
+    }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
 }); 

--- a/test/report/server.js
+++ b/test/report/server.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+
+// Serve static files from the report directory
+app.use(express.static(__dirname));
+
+// Serve PDFs from the test directory
+app.use('/test', express.static(path.join(__dirname, '..')));
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+    console.log(`Test report server running at http://localhost:${port}`);
+}); 

--- a/test/report/server.js
+++ b/test/report/server.js
@@ -1,14 +1,33 @@
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
+
 const app = express();
 
 // Serve static files from the report directory
-app.use(express.static(__dirname));
+app.use(express.static(path.join(__dirname)));
 
-// Serve PDFs from the test directory
+// Serve PDFs from test directory
 app.use('/test', express.static(path.join(__dirname, '..')));
 
-const port = process.env.PORT || 3000;
+// API endpoint to list actual PDFs
+app.get('/api/pdfs', (req, res) => {
+  const actualDir = path.join(__dirname, '../actual');
+  try {
+    const files = fs.readdirSync(actualDir)
+      .filter(file => file.endsWith('.pdf'))
+      .map(file => ({
+        name: file,
+        actualPdf: `test/actual/${file}`,
+        referencePdf: `test/reference/${file}`
+      }));
+    res.json(files);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const port = 3000;
 app.listen(port, () => {
-    console.log(`Test report server running at http://localhost:${port}`);
+  console.log(`Test report server running at http://localhost:${port}`);
 }); 

--- a/test/report/test-results.js
+++ b/test/report/test-results.js
@@ -1,8 +1,7 @@
 window.TEST_RESULTS = {
-  "summary": {
-    "passed": 488,
-    "skipped": 7,
-    "failed": 8
-  },
+  "total": 503,
+  "passed": 488,
+  "failed": 8,
+  "skipped": 7,
   "failures": []
 };

--- a/test/report/test-results.js
+++ b/test/report/test-results.js
@@ -1,0 +1,8 @@
+window.TEST_RESULTS = {
+  "summary": {
+    "passed": 488,
+    "skipped": 7,
+    "failed": 8
+  },
+  "failures": []
+};

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -2,6 +2,43 @@
 "use strict";
 const karmaConfig = require("../karma.common.conf.js");
 const resolve = require("rollup-plugin-node-resolve");
+const { generateReportData, writeReportData } = require('../report/generate-report-data');
+
+const TestReporter = function(baseReporterDecorator) {
+  baseReporterDecorator(this);
+
+  this.onRunComplete = function(browsers, results) {
+    const testResults = {
+      total: results.total,
+      passed: results.success,
+      failed: results.failed,
+      skipped: results.skipped,
+      failures: []
+    };
+
+    // Process failures
+    browsers.forEach(browser => {
+      if (browser.lastResult && browser.lastResult.failed) {
+        Object.values(browser.lastResult.failedSpecs || {}).forEach(failure => {
+          testResults.failures.push({
+            name: failure.suite.join(' ') + ' - ' + failure.description,
+            actualPdf: failure.log[0]?.match(/Actual PDF saved to: (.+\.pdf)/)?.[1],
+            referencePdf: 'test/reference/' + failure.log[0]?.match(/Actual PDF saved to: test\/actual\/(.+\.pdf)/)?.[1],
+            differences: {
+              total: failure.log[0]?.match(/Total differences: (\d+)/)?.[1] || 0,
+              patterns: []
+            }
+          });
+        });
+      }
+    });
+
+    const reportData = generateReportData(testResults);
+    writeReportData(reportData);
+  };
+};
+
+TestReporter.$inject = ['baseReporterDecorator'];
 
 module.exports = config => {
   config.set({
@@ -48,17 +85,27 @@ module.exports = config => {
       }
     },
 
-    browsers: ["Chrome", "Firefox"],
+    browsers: ["Chrome"],
+
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ["mocha", "coverage"],
+    reporters: ["mocha", "coverage", "test-report"],
 
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
     logLevel: config.LOG_INFO,
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true
+    autoWatch: true,
+
+    plugins: [
+      'karma-chrome-launcher',
+      'karma-coverage',
+      'karma-jasmine',
+      'karma-mocha-reporter',
+      'karma-rollup-preprocessor',
+      {'reporter:test-report': ['type', TestReporter]}
+    ]
   });
 };

--- a/test/utils/compare.js
+++ b/test/utils/compare.js
@@ -82,6 +82,297 @@ function resetFile(pdfFile) {
   pdfFile = pdfFile.replace(/\/Producer \([^)]+\)/, "/Producer (jsPDF 0.0.0)");
   return pdfFile;
 }
+
+function findRepeatedPattern(differences) {
+  if (differences.length < 2) return null;
+  
+  // Group differences by type
+  const groups = differences.reduce((acc, diff) => {
+    const type = getPdfLineType(diff.expected || diff.actual);
+    if (!acc[type]) acc[type] = [];
+    acc[type].push(diff);
+    return acc;
+  }, {});
+  
+  // Find patterns within each group
+  const patterns = [];
+  for (const [type, diffs] of Object.entries(groups)) {
+    if (diffs.length > 3) {
+      // Check if all differences in this group follow a similar pattern
+      const firstDiff = diffs[0];
+      const isConsistent = diffs.every(diff => 
+        (diff.actual === firstDiff.actual && diff.expected === firstDiff.expected) ||
+        (type === 'text-pos' && diff.actual?.endsWith(firstDiff.actual?.split(' ').pop()) && diff.expected?.endsWith(firstDiff.expected?.split(' ').pop()))
+      );
+      
+      if (isConsistent) {
+        patterns.push({
+          type,
+          count: diffs.length,
+          sample: firstDiff,
+          startLine: firstDiff.line,
+          consistent: true
+        });
+      } else {
+        patterns.push({
+          type,
+          count: diffs.length,
+          sample: firstDiff,
+          startLine: firstDiff.line,
+          consistent: false
+        });
+      }
+    }
+  }
+  
+  return patterns.length > 0 ? patterns : null;
+}
+
+function getPdfLineType(line) {
+  if (!line) return 'unknown';
+  // PDF structure elements
+  if (line.match(/^\d+ \d+ obj$/)) return 'obj-header';
+  if (line.match(/^\d{10} \d{5} [fn] $/)) return 'xref-entry';
+  if (line.match(/^endobj|stream|endstream$/)) return 'pdf-structure';
+  
+  // Font-related elements
+  if (line.startsWith('/BaseFont')) return 'font-def';
+  if (line.match(/^\/F\d+ \d+ \d+ R$/)) return 'font-ref';
+  if (line.match(/^\/F\d+ \d+ Tf$/)) return 'font-select';
+  
+  // Text operations
+  if (line.match(/^\d+\.\d+ \d+\.\d+ Td$/)) return 'text-pos';
+  if (line.match(/^BT|ET$/)) return 'text-block';
+  if (line.match(/^\d+\.\d+ TL$/)) return 'text-leading';
+  if (line.match(/^\(\S+\) Tj$/)) return 'text-show';
+  
+  // Graphics operations
+  if (line.match(/^\d+\.\d+ \d+\.\d+ \d+\.\d+ (rg|RG)$/)) return 'color';
+  if (line.match(/^[Qq]$/)) return 'graphics-state';
+  if (line.match(/^\d+\.\d+ w$/)) return 'line-width';
+  if (line.match(/^\d+\.\d+ \d+\.\d+ [ml]$/)) return 'path';
+  if (line.match(/^[WSFfBb]\*?$/)) return 'path-op';
+  if (line.match(/^[01] [JLj]$/)) return 'style';
+  
+  // Length and metadata
+  if (line.match(/^\/Length \d+$/)) return 'length';
+  if (line.match(/^\/Producer|\/CreationDate|\/Creator/)) return 'metadata';
+  
+  return 'unknown';
+}
+
+function compareArrays(actual, expected) {
+  let differences = [];
+  let consecutiveDiffs = 0;
+  let currentBlock = [];
+  
+  for (let i = 0; i < Math.max(actual.length, expected.length); i++) {
+    if (actual[i] !== expected[i]) {
+      consecutiveDiffs++;
+      currentBlock.push({
+        line: i + 1,
+        actual: actual[i],
+        expected: expected[i]
+      });
+    } else {
+      if (consecutiveDiffs > 0) {
+        const patterns = findRepeatedPattern(currentBlock);
+        if (patterns) {
+          differences.push({
+            patterns,
+            startLine: currentBlock[0].line,
+            count: currentBlock.length
+          });
+        } else if (currentBlock.length <= 3) {
+          differences.push(...currentBlock);
+        } else {
+          differences.push({
+            truncated: true,
+            count: currentBlock.length,
+            startLine: currentBlock[0].line,
+            sample: currentBlock[0]
+          });
+        }
+        currentBlock = [];
+      }
+      consecutiveDiffs = 0;
+    }
+  }
+  
+  // Handle any remaining differences
+  if (currentBlock.length > 0) {
+    const patterns = findRepeatedPattern(currentBlock);
+    if (patterns) {
+      differences.push({
+        patterns,
+        startLine: currentBlock[0].line,
+        count: currentBlock.length
+      });
+    } else if (currentBlock.length <= 3) {
+      differences.push(...currentBlock);
+    } else {
+      differences.push({
+        truncated: true,
+        count: currentBlock.length,
+        startLine: currentBlock[0].line,
+        sample: currentBlock[0]
+      });
+    }
+  }
+  
+  return differences;
+}
+
+const DIFFERENCE_DESCRIPTIONS = {
+  // PDF structure
+  'obj-header': 'Object header',
+  'xref-entry': 'Cross-reference entry',
+  'pdf-structure': 'PDF structure element',
+  
+  // Font-related
+  'font-def': 'Font definition',
+  'font-ref': 'Font reference',
+  'font-select': 'Font selection',
+  
+  // Text operations
+  'text-pos': 'Text position',
+  'text-block': 'Text block marker',
+  'text-leading': 'Text leading',
+  'text-show': 'Text content',
+  
+  // Graphics operations
+  'color': 'Color setting',
+  'graphics-state': 'Graphics state',
+  'line-width': 'Line width',
+  'path': 'Path command',
+  'path-op': 'Path operation',
+  'style': 'Style setting',
+  
+  // Length and metadata
+  'length': 'Content length',
+  'metadata': 'Document metadata',
+  
+  'unknown': 'Uncategorized'
+};
+
+function formatDifferences(differences) {
+  const MAX_DIFFERENCES_TO_SHOW = 10;
+  
+  let message = '';
+  let totalDiffs = 0;
+  let shownDiffs = 0;
+  
+  // First, count total differences
+  for (const diff of differences) {
+    if (diff.patterns) {
+      totalDiffs += diff.count;
+    } else if (diff.truncated) {
+      totalDiffs += diff.count;
+    } else {
+      totalDiffs++;
+    }
+  }
+  
+  message += `\nTotal differences: ${totalDiffs}\n`;
+  
+  // Group similar patterns together
+  const patternGroups = new Map();
+  
+  for (const diff of differences) {
+    if (diff.patterns) {
+      for (const pattern of diff.patterns) {
+        if (pattern.consistent) {
+          const key = `${pattern.type}:${pattern.sample.expected}:${pattern.sample.actual}`;
+          if (!patternGroups.has(key)) {
+            patternGroups.set(key, {
+              type: pattern.type,
+              sample: pattern.sample,
+              count: 0,
+              locations: []
+            });
+          }
+          const group = patternGroups.get(key);
+          group.count += pattern.count;
+          group.locations.push(`${pattern.startLine}-${pattern.startLine + pattern.count - 1}`);
+        }
+      }
+    }
+  }
+  
+  // Output grouped patterns first
+  if (patternGroups.size > 0) {
+    message += '\nConsistent patterns:\n';
+    for (const group of patternGroups.values()) {
+      if (shownDiffs >= MAX_DIFFERENCES_TO_SHOW) {
+        message += `\n... and ${patternGroups.size - shownDiffs} more consistent patterns\n`;
+        break;
+      }
+      message += `  - ${group.count} ${DIFFERENCE_DESCRIPTIONS[group.type]} differences:\n`;
+      const actualStr = group.sample.actual === undefined ? '<missing>' : group.sample.actual;
+      const expectedStr = group.sample.expected === undefined ? '<missing>' : group.sample.expected;
+      message += `    Expected: "${expectedStr}"\n    Actual:   "${actualStr}"\n`;
+      message += `    At lines: ${group.locations.join(', ')}\n`;
+      shownDiffs++;
+    }
+  }
+  
+  // Then output other differences
+  let remainingDiffsToShow = MAX_DIFFERENCES_TO_SHOW - shownDiffs;
+  let skippedDiffs = 0;
+  
+  for (const diff of differences) {
+    if (remainingDiffsToShow <= 0) {
+      skippedDiffs++;
+      continue;
+    }
+    
+    if (diff.patterns) {
+      const inconsistentPatterns = diff.patterns.filter(p => !p.consistent);
+      if (inconsistentPatterns.length > 0) {
+        message += `\nFound ${diff.count} differences at line ${diff.startLine}:\n`;
+        for (const pattern of inconsistentPatterns) {
+          if (remainingDiffsToShow <= 0) {
+            skippedDiffs++;
+            continue;
+          }
+          message += `  - ${pattern.count} ${DIFFERENCE_DESCRIPTIONS[pattern.type]} differences, e.g.:\n`;
+          const actualStr = pattern.sample.actual === undefined ? '<missing>' : pattern.sample.actual;
+          const expectedStr = pattern.sample.expected === undefined ? '<missing>' : pattern.sample.expected;
+          message += `    Expected: "${expectedStr}"\n    Actual:   "${actualStr}"\n`;
+          remainingDiffsToShow--;
+        }
+      }
+    } else if (diff.truncated) {
+      message += `\n${diff.count} differences at line ${diff.startLine} (showing first):\n`;
+      const actualStr = diff.sample.actual === undefined ? '<missing>' : diff.sample.actual;
+      const expectedStr = diff.sample.expected === undefined ? '<missing>' : diff.sample.expected;
+      const type = getPdfLineType(expectedStr || actualStr);
+      message += `  ${DIFFERENCE_DESCRIPTIONS[type]}:\n`;
+      message += `  Expected: "${expectedStr}"\n  Actual:   "${actualStr}"\n  ... and ${diff.count - 1} more differences\n`;
+      remainingDiffsToShow--;
+    } else {
+      const actualStr = diff.actual === undefined ? '<missing>' : diff.actual;
+      const expectedStr = diff.expected === undefined ? '<missing>' : diff.expected;
+      const type = getPdfLineType(expectedStr || actualStr);
+      
+      if (actualStr === '<missing>') {
+        message += `\nLine ${diff.line}: Extra ${DIFFERENCE_DESCRIPTIONS[type]}: "${expectedStr}"`;
+      } else if (expectedStr === '<missing>') {
+        message += `\nLine ${diff.line}: Extra ${DIFFERENCE_DESCRIPTIONS[type]}: "${actualStr}"`;
+      } else {
+        message += `\nLine ${diff.line} (${DIFFERENCE_DESCRIPTIONS[type]}):\n  Expected: "${expectedStr}"\n  Actual:   "${actualStr}"`;
+      }
+      remainingDiffsToShow--;
+    }
+  }
+  
+  if (skippedDiffs > 0) {
+    message += `\n\n... and ${skippedDiffs} more differences not shown`;
+  }
+  
+  return message;
+}
+
 /**
  * Find a better way to set this
  * @type {Boolean}
@@ -104,7 +395,13 @@ globalVar.comparePdf = function(actual, expectedFile, suite) {
   var expected = resetFile(pdf.replace(/^\s+|\s+$/g, ""));
   actual = resetFile(actual.replace(/^\s+|\s+$/g, ""));
 
-  expect(actual.replace(/[\r]/g, "").split("\n")).toEqual(
-    expected.replace(/[\r]/g, "").split("\n")
-  );
+  const actualLines = actual.replace(/[\r]/g, "").split("\n");
+  const expectedLines = expected.replace(/[\r]/g, "").split("\n");
+  
+  const differences = compareArrays(actualLines, expectedLines);
+  
+  if (differences.length > 0) {
+    const message = formatDifferences(differences);
+    fail(`PDF comparison failed:${message}`);
+  }
 };

--- a/test/utils/compare.js
+++ b/test/utils/compare.js
@@ -401,7 +401,12 @@ globalVar.comparePdf = function(actual, expectedFile, suite) {
   const differences = compareArrays(actualLines, expectedLines);
   
   if (differences.length > 0) {
+    // Save the actual PDF for debugging
+    globalVar.sendReference(
+      "/test/actual/" + expectedFile,
+      resetFile(actual)
+    );
     const message = formatDifferences(differences);
-    fail(`PDF comparison failed:${message}`);
+    fail(`PDF comparison failed:${message}\nActual PDF saved to: test/actual/${expectedFile}`);
   }
 };

--- a/test/utils/compare.js
+++ b/test/utils/compare.js
@@ -387,7 +387,7 @@ globalVar.comparePdf = function(actual, expectedFile, suite) {
   } catch (error) {
     fail(error.message);
     globalVar.savePdf(
-      "/test/reference/" + expectedFile,
+      "/test/actual/" + expectedFile,
       resetFile(actual.replace(/^\s+|\s+$/g, ""))
     );
     return;

--- a/test/utils/compare.js
+++ b/test/utils/compare.js
@@ -6,7 +6,7 @@ var globalVar =
   (typeof window !== "undefined" && window) ||
   Function("return this")();
 
-globalVar.sendReference = function() {};
+globalVar.savePdf = function() {};
 globalVar.loadBinaryResource = function() {};
 
 var prefix = globalVar.isNode ? "/../" : "/base/test/";
@@ -26,7 +26,7 @@ if (globalVar.isNode === true) {
     return result;
   };
 } else {
-  globalVar.sendReference = function(filename, data) {
+  globalVar.savePdf = function(filename, data) {
     const req = new XMLHttpRequest();
     req.open("POST", `http://localhost:9090${filename}`, true);
     req.setRequestHeader("Content-Type", "text/plain; charset=x-user-defined");
@@ -386,7 +386,7 @@ globalVar.comparePdf = function(actual, expectedFile, suite) {
     }
   } catch (error) {
     fail(error.message);
-    globalVar.sendReference(
+    globalVar.savePdf(
       "/test/reference/" + expectedFile,
       resetFile(actual.replace(/^\s+|\s+$/g, ""))
     );
@@ -402,7 +402,7 @@ globalVar.comparePdf = function(actual, expectedFile, suite) {
   
   if (differences.length > 0) {
     // Save the actual PDF for debugging
-    globalVar.sendReference(
+    globalVar.savePdf(
       "/test/actual/" + expectedFile,
       resetFile(actual)
     );


### PR DESCRIPTION
Improves PDF test debugging with:
- Detailed error messages showing exact differences between expected/actual PDFs
- Failed PDFs automatically saved to `test/actual/` for inspection
- New web UI for comparing test results (`npm run test-report`)

<img width="1606" alt="Screenshot 2024-12-25 at 07 35 38" src="https://github.com/user-attachments/assets/ea60fa8a-fda0-4a05-98bf-54088c2e0e2a" />


Changes:
- Added test report server and UI
- Improved test failure messages with pattern detection (text, graphics, metadata, etc.)
- Renamed `sendReference` to `savePdf` for clarity
- Added PDF comparison tools and viewers (sync'd PDF scrolling)

To use: Run tests normally, then `npm run test-report` to view results at `http://localhost:3000`

## Left to do

- [ ] Visual difference between the two might be nice