### PR TITLE
Fix cell.js getTextDimensions doesn't respect lineHeightFactor option

### DIFF
--- a/src/modules/cell.js
+++ b/src/modules/cell.js
@@ -171,10 +171,17 @@ import { jsPDF } from "../jspdf.js";
   };
 
   /**
+   * Gets height and width of text
    * @name getTextDimensions
    * @function
    * @param {string} txt
-   * @returns {Object} dimensions
+   * @param {object} [options]
+   * @param {string} [options.font] Font name or family. Example: "times"
+   * @param {number} [options.fontSize] Font size in points
+   * @param {number} [options.lineHeightFactor=1.15]  The lineheight of each line
+   * @param {number} [options.maxWidth=0] Split the text by given width, 0 = no split
+   * @param {number} [options.scaleFactor] Defaults to value determined by unit declared at inception of PDF  document
+   * @returns {object} `{ w: ${width}, h: ${height} }` (in units declared at inception of PDF document)
    */
   jsPDFAPI.getTextDimensions = function(text, options) {
     _initialize.call(this);
@@ -182,6 +189,9 @@ import { jsPDF } from "../jspdf.js";
     var fontSize = options.fontSize || this.getFontSize();
     var font = options.font || this.getFont();
     var scaleFactor = options.scaleFactor || this.internal.scaleFactor;
+    var lineHeightFactor =
+      options.lineHeightFactor || this.internal.getLineHeightFactor();
+    const maxWidth = options.maxWidth || 0;
     var width = 0;
     var amountOfLines = 0;
     var height = 0;
@@ -198,7 +208,6 @@ import { jsPDF } from "../jspdf.js";
       }
     }
 
-    const maxWidth = options.maxWidth;
     if (maxWidth > 0) {
       if (typeof text === "string") {
         text = this.splitTextToSize(text, maxWidth);
@@ -225,8 +234,8 @@ import { jsPDF } from "../jspdf.js";
 
     width = width / scaleFactor;
     height = Math.max(
-      (amountOfLines * fontSize * this.getLineHeightFactor() -
-        fontSize * (this.getLineHeightFactor() - 1)) /
+      (amountOfLines * fontSize * lineHeightFactor -
+        fontSize * (lineHeightFactor - 1)) /
         scaleFactor,
       0
     );

--- a/test/specs/cell.spec.js
+++ b/test/specs/cell.spec.js
@@ -21,10 +21,22 @@ describe("Module: Cell", () => {
       doc.getTextDimensions("Octocat loves jsPDF", { maxWidth: 150 }).h
     ).toEqual(16);
     expect(
+      doc.getTextDimensions("Octocat loves jsPDF", { maxWidth: 150, lineHeightFactor: 2 }).h
+    ).toEqual(16);
+    expect(
       doc.getTextDimensions("Octocat loves jsPDF", { maxWidth: 100 }).h
     ).toEqual(34.4);
     expect(
+      doc.getTextDimensions("Octocat loves jsPDF", { maxWidth: 100, lineHeightFactor: undefined }).h
+    ).toEqual(34.4);
+    expect(
+      doc.getTextDimensions("Octocat loves jsPDF", { maxWidth: 100, lineHeightFactor: 2 }).h
+    ).toEqual(48);
+    expect(
       doc.getTextDimensions("Octocat loves jsPDF", { maxWidth: 100 }).w
+    ).toEqual(96.64000000000001);
+    expect(
+      doc.getTextDimensions("Octocat loves jsPDF", { maxWidth: 100, lineHeightFactor: 2 }).w
     ).toEqual(96.64000000000001);
     expect(
       doc.getTextDimensions("Octocat loves jsPDF\njsPDF loves Octocat", { maxWidth: 100 }).h


### PR DESCRIPTION
**Before/After**
![image](https://github.com/user-attachments/assets/cf82bdcc-5035-4d31-bf04-f3418d46960b)

```JavaScript
var doc = new jsPDF();
const textOptions = {
  maxWidth: 50,
  lineHeightFactor: 1.5
};

const paragraphs = [
  '1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean tempor leo tellus, ut luctus mi aliquet a. Aenean id mauris volutpat, ullamcorper libero a, bibendum leo. Praesent ut enim sapien. Ut et felis interdum, molestie eros quis, facilisis odio.',
  '2. Cras risus ex, dapibus eu interdum in, placerat eu neque. Quisque venenatis tellus ac aliquam eleifend.',
  '3. Nunc ex urna, laoreet a gravida molestie, bibendum ac tellus. Nulla finibus sed lectus porta elementum. Suspendisse potenti. Sed quis purus at nunc sollicitudin posuere.',
];

let y = 15;
paragraphs.forEach(paragraph => {
  const height = doc.getTextDimensions(paragraph, textOptions).h;
  doc.text(paragraph, 15, y, textOptions);
  y += height + 5;
});

```