### PR TITLE
Fix Incorrect Typing for Margins in the TableConfig Interface Definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -607,7 +607,12 @@ declare module "jspdf" {
   export interface TableConfig {
     printHeaders?: boolean;
     autoSize?: boolean;
-    margins?: number;
+    margins?: {
+      top: number,
+      bottom: number,
+      left: number,
+      width: number
+    };
     fontSize?: number;
     padding?: number;
     headerBackgroundColor?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -608,10 +608,10 @@ declare module "jspdf" {
     printHeaders?: boolean;
     autoSize?: boolean;
     margins?: {
-      top: number,
-      bottom: number,
-      left: number,
-      width: number
+      top: number;
+      bottom: number;
+      left: number;
+      width: number;
     };
     fontSize?: number;
     padding?: number;


### PR DESCRIPTION
Related to #3815

This change addresses an issue with the typing of the `margins` property in the `TableConfig` interface definition.

The `config` parameter in the `table` function can include a `margins` object with the following properties: `top`, `bottom`, `left`, and `width`. However, the `TableConfig` interface incorrectly defines `margins` as a `number` instead of the correct object type. This inconsistency leads to type-related issues when using the `margins` property as an object.

See [this](https://github.com/parallax/jsPDF/blob/master/dist/jspdf.node.js#L12363) for the expected value of `margins`.
See [this](https://github.com/parallax/jsPDF/blob/master/types/index.d.ts#L1076) for the `config` parameter in `table` function.