### PR TITLE
Add support for TextFields with same fieldName, ie. TextFieldGroups

### DIFF
--- a/examples/js/acroforms.js
+++ b/examples/js/acroforms.js
@@ -8,72 +8,145 @@ var {
   TextField,
   PasswordField,
   RadioButton,
-  Appearance
+  Appearance,
+  TextFieldGroup
 } = jsPDF.AcroForm;
 
 doc.setFontSize(12);
-doc.text("ComboBox:", 10, 105);
+var margin = 12;
+let yPos = 20;
 
-var comboBox = new ComboBox();
-comboBox.fieldName = "ChoiceField1";
-comboBox.topIndex = 1;
-comboBox.Rect = [50, 100, 30, 10];
-comboBox.setOptions(["a", "b", "c"]);
-comboBox.value = "b";
-comboBox.defaultValue = "b";
-doc.addField(comboBox);
+addComboBox();
+addListBox();
+addCheckBox();
+addPushButton();
+addTextField();
+addPasswordField();
+addRadioGroups();
+addTextFieldGroup();
 
-doc.text("ListBox:", 10, 115);
-var listbox = new ListBox();
-listbox.edit = false;
-listbox.fieldName = "ChoiceField2";
-listbox.topIndex = 2;
-listbox.Rect = [50, 110, 30, 10];
-listbox.setOptions(["c", "a", "d", "f", "b", "s"]);
-listbox.value = "s";
-doc.addField(listbox);
+function addComboBox() {
+  doc.text("ComboBox:", 10, yPos);
+  var comboBox = new ComboBox();
+  comboBox.fieldName = "ComboBox1";
+  comboBox.topIndex = 1;
+  comboBox.Rect = [50, yPos - 5, 30, 10];
+  comboBox.setOptions(["a", "b", "c"]);
+  comboBox.value = "b";
+  comboBox.defaultValue = "b";
+  doc.addField(comboBox);
+  yPos += margin;
+}
 
-doc.text("CheckBox:", 10, 125);
-var checkBox = new CheckBox();
-checkBox.fieldName = "CheckBox1";
-checkBox.Rect = [50, 120, 30, 10];
-doc.addField(checkBox);
+function addListBox() {
+  doc.text("ListBox:", 10, yPos);
+  var listbox = new ListBox();
+  listbox.edit = false;
+  listbox.fieldName = "ListBox1";
+  listbox.topIndex = 2;
+  listbox.Rect = [50, yPos - 5, 30, 10];
+  listbox.setOptions(["c", "a", "d", "f", "b", "s"]);
+  listbox.value = "s";
+  doc.addField(listbox);
+  yPos += margin;
+}
 
-doc.text("PushButton:", 10, 135);
-var pushButton = new PushButton();
-pushButton.fieldName = "PushButton1";
-pushButton.Rect = [50, 130, 30, 10];
-doc.addField(pushButton);
+function addCheckBox() {
+  doc.text("CheckBox:", 10, yPos);
+  var checkBox = new CheckBox();
+  checkBox.fieldName = "CheckBox1";
+  checkBox.Rect = [50, yPos - 5, 30, 10];
+  doc.addField(checkBox);
+  yPos += margin;
+}
 
-doc.text("TextField:", 10, 145);
-var textField = new TextField();
-textField.Rect = [50, 140, 30, 10];
-textField.multiline = true;
-textField.value =
-  "The quick brown fox ate the lazy mouse The quick brown fox ate the lazy mouse The quick brown fox ate the lazy mouse"; //
-textField.fieldName = "TestTextBox";
-doc.addField(textField);
+function addPushButton() {
+  doc.text("PushButton:", 10, yPos);
+  var pushButton = new PushButton();
+  pushButton.fieldName = "PushButton1";
+  pushButton.Rect = [50, yPos - 5, 30, 10];
+  doc.addField(pushButton);
+  yPos += margin;
+}
 
-doc.text("Password:", 10, 155);
-var passwordField = new PasswordField();
-passwordField.Rect = [50, 150, 30, 10];
-doc.addField(passwordField);
+function addTextField() {
+  doc.text("TextField:", 10, yPos);
+  var textField = new TextField();
+  textField.Rect = [50, yPos - 5, 40, 10];
+  textField.multiline = true;
+  textField.value =
+    "The quick brown fox ate the lazy mouse The quick brown fox ate the lazy mouse The quick brown fox ate the lazy mouse";
+  textField.fieldName = "TestTextBox";
+  doc.addField(textField);
+  yPos += margin;
+}
 
-doc.text("RadioGroup:", 50, 165);
-var radioGroup = new RadioButton();
-radioGroup.value = "Test";
-radioGroup.Subtype = "Form";
+function addPasswordField() {
+  doc.text("Password:", 10, yPos);
+  var passwordField = new PasswordField();
+  passwordField.Rect = [50, yPos - 5, 40, 10];
+  doc.addField(passwordField);
+  yPos += margin;
+}
 
-doc.addField(radioGroup);
+function addRadioGroups() {
+  var boxDim = 10;
+  doc.text("RadioGroups:", 10, yPos);
 
-var radioButton1 = radioGroup.createOption("Test");
-radioButton1.Rect = [50, 170, 30, 10];
-radioButton1.AS = "/Test";
+  // First radio group
+  var radioGroup = new RadioButton();
+  radioGroup.value = "RadioGroup1Option3";
+  radioGroup.fieldName = "RadioGroup1";
+  doc.addField(radioGroup);
+  yPos -= 5;
 
-var radioButton2 = radioGroup.createOption("Test2");
-radioButton2.Rect = [50, 180, 30, 10];
+  var radioButton1 = radioGroup.createOption("RadioGroup1Option1");
+  radioButton1.Rect = [50, yPos, boxDim, boxDim];
 
-var radioButton3 = radioGroup.createOption("Test3");
-radioButton3.Rect = [50, 190, 20, 10];
+  var radioButton2 = radioGroup.createOption("RadioGroup1Option2");
+  radioButton2.Rect = [62, yPos, boxDim, boxDim];
 
-radioGroup.setAppearance(Appearance.RadioButton.Cross);
+  var radioButton3 = radioGroup.createOption("RadioGroup1Option3");
+  radioButton3.Rect = [74, yPos, boxDim, boxDim];
+  radioButton3.AS = "/RadioGroup1Option3";
+
+  radioGroup.setAppearance(Appearance.RadioButton.Cross);
+  yPos += boxDim + 5;
+
+  // Second radio group
+  var radioGroup2 = new RadioButton("RadioGroup2");
+  radioGroup2.value = "RadioGroup2Option3";
+  radioGroup2.fieldName = "RadioGroup2";
+
+  doc.addField(radioGroup2);
+
+  var radioButton21 = radioGroup2.createOption("RadioGroup2Option1");
+  radioButton21.Rect = [50, yPos, boxDim, boxDim];
+
+  var radioButton22 = radioGroup2.createOption("RadioGroup2Option2");
+  radioButton22.Rect = [62, yPos, boxDim, boxDim];
+
+  var radioButton23 = radioGroup2.createOption("RadioGroup2Option3");
+  radioButton23.Rect = [74, yPos, boxDim, boxDim];
+  radioButton23.AS = "/RadioGroup2Option3";
+
+  radioGroup2.setAppearance(Appearance.RadioButton.Circle);
+  yPos += margin + boxDim;
+}
+
+function addTextFieldGroup() {
+  doc.text("TextField Group:", 10, yPos);
+
+  const txtDate = new TextFieldGroup();
+  txtDate.fieldName = "Date";
+  txtDate.value = new Date().toLocaleDateString("en-US");
+  doc.addField(txtDate);
+
+  const txtDate1 = txtDate.createChild();
+  txtDate1.Rect = [50, yPos - 5, 40, 10];
+
+  yPos += margin;
+
+  const txtDate2 = txtDate.createChild();
+  txtDate2.Rect = [50, yPos - 5, 40, 10];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "rollup-plugin-license": "^2.1.0",
         "rollup-plugin-node-resolve": "5.2.0",
         "rollup-plugin-preprocess": "0.0.4",
-        "rollup-plugin-terser": "^6.1.0",
+        "rollup-plugin-terser": "^7.0.2",
         "typescript": "^5.6.2",
         "yarpm": "^0.2.1"
       },
@@ -1650,6 +1650,64 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@koa/cors": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-3.1.0.tgz",
@@ -3218,9 +3276,9 @@
       "dev": true
     },
     "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
     "node_modules/buffer-xor": {
@@ -7063,16 +7121,17 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.1.0.tgz",
-      "integrity": "sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
       "dev": true,
       "dependencies": {
+        "@types/node": "*",
         "merge-stream": "^2.0.0",
         "supports-color": "^7.0.0"
       },
       "engines": {
-        "node": ">= 10.14.2"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/jest-worker/node_modules/has-flag": {
@@ -7085,9 +7144,9 @@
       }
     },
     "node_modules/jest-worker/node_modules/supports-color": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -10293,16 +10352,16 @@
       }
     },
     "node_modules/rollup-plugin-terser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-6.1.0.tgz",
-      "integrity": "sha512-4fB3M9nuoWxrwm39habpd4hvrbrde2W2GG4zEGPQg1YITNkM3Tqur5jSuXlWNzbv/2aMLJ+dZJaySc3GCD8oDw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
       "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.8.3",
-        "jest-worker": "^26.0.0",
-        "serialize-javascript": "^3.0.0",
-        "terser": "^4.7.0"
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
       },
       "peerDependencies": {
         "rollup": "^2.0.0"
@@ -10793,9 +10852,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-      "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -11065,9 +11124,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -11580,20 +11639,33 @@
       }
     },
     "node_modules/terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
+      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
       "dev": true,
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
         "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
+        "source-map-support": "~0.5.20"
       },
       "bin": {
         "terser": "bin/terser"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/terser/node_modules/commander": {
@@ -11601,15 +11673,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
-    },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "rollup-plugin-license": "^2.1.0",
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-preprocess": "0.0.4",
-    "rollup-plugin-terser": "^6.1.0",
+    "rollup-plugin-terser": "^7.0.2",
     "typescript": "^5.6.2",
     "yarpm": "^0.2.1"
   },

--- a/test/deployment/amd/loadGlobals.js
+++ b/test/deployment/amd/loadGlobals.js
@@ -25,6 +25,7 @@ window.loadGlobals = function loadGlobals() {
       window.PushButton = jsPDF.AcroFormPushButton;
       window.RadioButton = jsPDF.AcroFormRadioButton;
       window.CheckBox = jsPDF.AcroFormCheckBox;
+      window.TextFieldGroup = jsPDF.AcroFormTextFieldGroup;
       window.TextField = jsPDF.AcroFormTextField;
       window.PasswordField = jsPDF.AcroFormPasswordField;
       window.Appearance = jsPDF.AcroFormAppearance;

--- a/test/deployment/esm/asyncImportHelper.js
+++ b/test/deployment/esm/asyncImportHelper.js
@@ -10,6 +10,7 @@ import {
   AcroFormRadioButton,
   AcroFormCheckBox,
   AcroFormTextField,
+  AcroFormTextFieldGroup,
   AcroFormPasswordField,
   AcroFormAppearance
 } from "../../../dist/jspdf.es.js";
@@ -26,6 +27,7 @@ window.importsReady({
   AcroFormRadioButton,
   AcroFormCheckBox,
   AcroFormTextField,
+  AcroFormTextFieldGroup,
   AcroFormPasswordField,
   AcroFormAppearance
 });

--- a/test/deployment/esm/loadGlobals.js
+++ b/test/deployment/esm/loadGlobals.js
@@ -21,6 +21,7 @@ window.loadGlobals = async function loadGlobals() {
   window.PushButton = jsPDF.AcroFormPushButton;
   window.RadioButton = jsPDF.AcroFormRadioButton;
   window.CheckBox = jsPDF.AcroFormCheckBox;
+  window.TextFieldGroup = jsPDF.AcroFormTextFieldGroup;
   window.TextField = jsPDF.AcroFormTextField;
   window.PasswordField = jsPDF.AcroFormPasswordField;
   window.Appearance = jsPDF.AcroFormAppearance;

--- a/test/deployment/globals/loadGlobals.js
+++ b/test/deployment/globals/loadGlobals.js
@@ -14,6 +14,7 @@ window.loadGlobals = function loadGlobals() {
   window.RadioButton = jsPDF.AcroFormRadioButton;
   window.CheckBox = jsPDF.AcroFormCheckBox;
   window.TextField = jsPDF.AcroFormTextField;
+  window.TextFieldGroup = jsPDF.AcroFormTextFieldGroup;
   window.PasswordField = jsPDF.AcroFormPasswordField;
   window.Appearance = jsPDF.AcroFormAppearance;
   window.Canvg = window.canvg.Canvg;

--- a/test/deployment/node/loadGlobals.js
+++ b/test/deployment/node/loadGlobals.js
@@ -15,6 +15,7 @@ global.loadGlobals = function() {
   global.PushButton = jsPDF.AcroFormPushButton;
   global.RadioButton = jsPDF.AcroFormRadioButton;
   global.CheckBox = jsPDF.AcroFormCheckBox;
+  global.TextFieldGroup = jsPDF.AcroFormTextFieldGroup;
   global.TextField = jsPDF.AcroFormTextField;
   global.PasswordField = jsPDF.AcroFormPasswordField;
   global.Appearance = jsPDF.AcroFormAppearance;

--- a/test/reference/textfieldGroup.pdf
+++ b/test/reference/textfieldGroup.pdf
@@ -1,0 +1,471 @@
+%PDF-1.3
+%ºß¬à
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 419.53 297.64]
+/Annots [
+ 7 0 R 
+ 8 0 R 
+]
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<<
+/Length 151
+>>
+stream
+0.57 w
+0 G
+BT
+/F1 16 Tf
+18.4 TL
+0 g
+14.17 272.13 Td
+(Name:) Tj
+ET
+BT
+/F1 16 Tf
+18.4 TL
+0 g
+262.31 272.13 Td
+(Date:) Tj
+ET
+0. 257.95 m
+419.53 257.95 l
+S
+endstream
+endobj
+5 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 419.53 297.64]
+/Annots [
+ 9 0 R 
+ 10 0 R 
+]
+/Contents 6 0 R
+>>
+endobj
+6 0 obj
+<<
+/Length 151
+>>
+stream
+0.57 w
+0 G
+BT
+/F1 16 Tf
+18.4 TL
+0 g
+14.17 272.13 Td
+(Name:) Tj
+ET
+BT
+/F1 16 Tf
+18.4 TL
+0 g
+262.31 272.13 Td
+(Date:) Tj
+ET
+0. 257.95 m
+419.53 257.95 l
+S
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R 5 0 R ]
+/Count 2
+>>
+endobj
+11 0 obj
+<<
+/Fields [12 0 R 13 0 R 7 0 R 8 0 R 9 0 R 10 0 R]
+>>
+endobj
+12 0 obj
+<<
+/FT /Tx
+/T (Name)
+/V (Smith, Robert)
+/Kids [7 0 R 9 0 R]
+>>
+endobj
+13 0 obj
+<<
+/FT /Tx
+/T (Date)
+/V (12/31/2033)
+/Kids [8 0 R 10 0 R]
+>>
+endobj
+7 0 obj
+<<
+/F 4
+/Rect [63.89 263.62 233.97 289.14]
+/FT /Tx
+/Type /Annot
+/Subtype /Widget
+/Parent 12 0 R
+/AP <</N 14 0 R>>
+>>
+endobj
+8 0 obj
+<<
+/F 4
+/Rect [303.23 263.62 402.44 289.14]
+/FT /Tx
+/Type /Annot
+/Subtype /Widget
+/Parent 13 0 R
+/AP <</N 15 0 R>>
+>>
+endobj
+9 0 obj
+<<
+/F 4
+/Rect [63.89 263.62 233.97 289.14]
+/FT /Tx
+/Type /Annot
+/Subtype /Widget
+/Parent 12 0 R
+/AP <</N 16 0 R>>
+>>
+endobj
+10 0 obj
+<<
+/F 4
+/Rect [303.23 263.62 402.44 289.14]
+/FT /Tx
+/Type /Annot
+/Subtype /Widget
+/Parent 13 0 R
+/AP <</N 17 0 R>>
+>>
+endobj
+14 0 obj
+<<
+/Type /XObject
+/Subtype /Form
+/FormType 1
+/BBox [0 0 170.08 25.51]
+/Resources 2 0 R
+/Length 95
+>>
+stream
+/Tx BMC
+q
+BT
+0. g
+/F1 17.64 Tf
+1 0 0 1 0 0 Tm
+2.00 7.48 Td
+(Smith, Robert) Tj
+-2 0 Td
+
+ET
+Q
+EMC
+endstream
+endobj
+15 0 obj
+<<
+/Type /XObject
+/Subtype /Form
+/FormType 1
+/BBox [0 0 99.21 25.51]
+/Resources 2 0 R
+/Length 92
+>>
+stream
+/Tx BMC
+q
+BT
+0. g
+/F1 17.64 Tf
+1 0 0 1 0 0 Tm
+2.00 7.48 Td
+(12/31/2033) Tj
+-2 0 Td
+
+ET
+Q
+EMC
+endstream
+endobj
+16 0 obj
+<<
+/Type /XObject
+/Subtype /Form
+/FormType 1
+/BBox [0 0 170.08 25.51]
+/Resources 2 0 R
+/Length 95
+>>
+stream
+/Tx BMC
+q
+BT
+0. g
+/F1 17.64 Tf
+1 0 0 1 0 0 Tm
+2.00 7.48 Td
+(Smith, Robert) Tj
+-2 0 Td
+
+ET
+Q
+EMC
+endstream
+endobj
+17 0 obj
+<<
+/Type /XObject
+/Subtype /Form
+/FormType 1
+/BBox [0 0 99.21 25.51]
+/Resources 2 0 R
+/Length 92
+>>
+stream
+/Tx BMC
+q
+BT
+0. g
+/F1 17.64 Tf
+1 0 0 1 0 0 Tm
+2.00 7.48 Td
+(12/31/2033) Tj
+-2 0 Td
+
+ET
+Q
+EMC
+endstream
+endobj
+18 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+19 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+20 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-Oblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+21 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-BoldOblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+22 0 obj
+<<
+/Type /Font
+/BaseFont /Courier
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+23 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+24 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-Oblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+25 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-BoldOblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+26 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+27 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+28 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Italic
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+29 0 obj
+<<
+/Type /Font
+/BaseFont /Times-BoldItalic
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+30 0 obj
+<<
+/Type /Font
+/BaseFont /ZapfDingbats
+/Subtype /Type1
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+31 0 obj
+<<
+/Type /Font
+/BaseFont /Symbol
+/Subtype /Type1
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 18 0 R
+/F2 19 0 R
+/F3 20 0 R
+/F4 21 0 R
+/F5 22 0 R
+/F6 23 0 R
+/F7 24 0 R
+/F8 25 0 R
+/F9 26 0 R
+/F10 27 0 R
+/F11 28 0 R
+/F12 29 0 R
+/F13 30 0 R
+/F14 31 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+32 0 obj
+<<
+/Producer (jsPDF 0.0.0)
+/CreationDate (D:19871210000000+00'00')
+>>
+endobj
+33 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+/AcroForm 11 0 R
+>>
+endobj
+xref
+0 34
+0000000000 65535 f 
+0000000694 00000 n 
+0000004192 00000 n 
+0000000015 00000 n 
+0000000152 00000 n 
+0000000354 00000 n 
+0000000492 00000 n 
+0000000984 00000 n 
+0000001116 00000 n 
+0000001249 00000 n 
+0000001381 00000 n 
+0000000757 00000 n 
+0000000828 00000 n 
+0000000907 00000 n 
+0000001515 00000 n 
+0000001745 00000 n 
+0000001971 00000 n 
+0000002201 00000 n 
+0000002427 00000 n 
+0000002553 00000 n 
+0000002684 00000 n 
+0000002818 00000 n 
+0000002956 00000 n 
+0000003080 00000 n 
+0000003209 00000 n 
+0000003341 00000 n 
+0000003477 00000 n 
+0000003605 00000 n 
+0000003732 00000 n 
+0000003861 00000 n 
+0000003994 00000 n 
+0000004096 00000 n 
+0000004445 00000 n 
+0000004531 00000 n 
+trailer
+<<
+/Size 34
+/Root 33 0 R
+/Info 32 0 R
+/ID [ <00000000000000000000000000000000> <00000000000000000000000000000000> ]
+>>
+startxref
+4652
+%%EOF

--- a/test/saucelabs/loadGlobals.js
+++ b/test/saucelabs/loadGlobals.js
@@ -14,6 +14,7 @@ window.loadGlobals = function loadGlobals() {
   window.RadioButton = jsPDF.AcroFormRadioButton;
   window.CheckBox = jsPDF.AcroFormCheckBox;
   window.TextField = jsPDF.AcroFormTextField;
+  window.TextFieldGroup = jsPDF.AcroFormTextFieldGroup;
   window.PasswordField = jsPDF.AcroFormPasswordField;
   window.Appearance = jsPDF.AcroFormAppearance;
   window.Canvg = window.canvg.Canvg;

--- a/test/unit/asyncImportHelper.js
+++ b/test/unit/asyncImportHelper.js
@@ -10,6 +10,7 @@ import {
   AcroFormRadioButton,
   AcroFormCheckBox,
   AcroFormTextField,
+  AcroFormTextFieldGroup,
   AcroFormPasswordField,
   AcroFormAppearance
 } from "/base/src/index.js";
@@ -26,6 +27,7 @@ window.importsReady({
   AcroFormRadioButton,
   AcroFormCheckBox,
   AcroFormTextField,
+  AcroFormTextFieldGroup,
   AcroFormPasswordField,
   AcroFormAppearance
 });

--- a/test/unit/loadGlobals.js
+++ b/test/unit/loadGlobals.js
@@ -22,6 +22,7 @@ window.loadGlobals = async function loadGlobals() {
   window.RadioButton = jsPDF.AcroFormRadioButton;
   window.CheckBox = jsPDF.AcroFormCheckBox;
   window.TextField = jsPDF.AcroFormTextField;
+  window.TextFieldGroup = jsPDF.AcroFormTextFieldGroup;
   window.PasswordField = jsPDF.AcroFormPasswordField;
   window.Appearance = jsPDF.AcroFormAppearance;
   window.Canvg = window.canvg.Canvg;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -367,6 +367,17 @@ declare module "jspdf" {
     hasAppearanceStream: boolean;
   }
 
+  export class AcroFormTextFieldGroup {}
+  export interface AcroFormTextFieldGroup extends AcroFormTextField {
+    Kids: AcroFormTextFieldChild[];
+    createChild(): AcroFormTextFieldChild;
+  }
+
+  export class AcroFormTextFieldChild {}
+  export interface AcroFormTextFieldChild extends AcroFormTextField {
+    Parent: AcroFormTextFieldGroup;
+  }
+
   export class AcroFormPasswordField {}
   export interface AcroFormPasswordField extends AcroFormTextField {}
   // jsPDF plugin: Context2D


### PR DESCRIPTION
A use case for this feature is multi-page documents with fields that are duplicated on each page (e.g. name and date on medical forms). Resolves #3361

Also, upgrade "rollup-plugin-terser" from 6.1.0 to 7.0.2 for optional chaining support.

Let me know if you'd like me to submit a pull request that combines this one with #3813

**Example:**
![jsPdf](https://github.com/user-attachments/assets/3547f45a-9ed5-403d-88bb-d995b522b8f2)

```js
var { TextFieldGroup } = jsPDF.AcroForm;

var doc = new jsPDF({
  format: "a6",
  orientation: "landscape",
  unit: "mm",
  floatPrecision: 2
});

var txtName = new TextFieldGroup();
txtName.fieldName = "Name";
doc.addField(txtName);

var txtDate = new TextFieldGroup();
txtDate.fieldName = "Date";
doc.addField(txtDate);

addHeader();
doc.addPage();
addHeader();

function addHeader() {
  let yPos = 9;
  let xPos = 5;
  let txtChild;

  doc.text("Name:", xPos, yPos);
  xPos += doc.getTextWidth("Name:") + 1;
  txtChild = txtName.createChild();
  txtChild.Rect = [xPos, yPos - 6, 60, 9];

  xPos += 70;

  doc.text("Date:", xPos, yPos);
  xPos += doc.getTextWidth("Date:") + 1;
  txtChild = txtDate.createChild();
  txtChild.Rect = [xPos, yPos - 6, 35, 9];

  yPos += 5;
  doc.line(0, yPos, doc.internal.pageSize.width, yPos);
}
```
