### PR TITLE
fix(sec): remove MSIE support to allow upgrading to vuln-free `dompurify` v3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ preparing a pull request please follow these guidelines:
 - You may now (and should!) use modern JavaScript everywhere. The build step will transpile it. Most of the sources
   are still in ES5, but all new code should be written in ES6+.
 - When using newer EcmaScript or Browser APIs make sure the required polyfills are listed in
-  `src/polyfills.js`. At the moment, the library must still run in IE11!
+  `src/polyfills.js`.
 - Run `npm run prettier` before committing.
 - Don't update the files in `dist` in regular pull requests. These are usually only updated when creating a new release.
 - For the commit message, follow these guidelines:

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   "optionalDependencies": {
     "canvg": "^3.0.6",
     "core-js": "^3.6.0",
-    "dompurify": "^2.0.12",
+    "dompurify": "^3.2.4",
     "html2canvas": "^1.0.0-rc.5"
   },
   "devDependencies": {

--- a/docs/libs_Blob.js.html
+++ b/docs/libs_Blob.js.html
@@ -459,26 +459,6 @@ if (strTag) {
 }
 
 function fixFileAndXHR() {
-  var isIE =
-    !!global.ActiveXObject ||
-    ("-ms-scroll-limit" in document.documentElement.style &amp;&amp;
-      "-ms-ime-align" in document.documentElement.style);
-
-  // Monkey patched
-  // IE don't set Content-Type header on XHR whose body is a typed Blob
-  // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/6047383
-  var _send = global.XMLHttpRequest &amp;&amp; global.XMLHttpRequest.prototype.send;
-  if (isIE &amp;&amp; _send) {
-    XMLHttpRequest.prototype.send = function(data) {
-      if (data instanceof Blob) {
-        this.setRequestHeader("Content-Type", data.type);
-        _send.call(this, data);
-      } else {
-        _send.call(this, data);
-      }
-    };
-  }
-
   try {
     new File([], "");
   } catch (e) {

--- a/examples/PDF.js/build/pdf.js
+++ b/examples/PDF.js/build/pdf.js
@@ -17864,11 +17864,10 @@
 
           var userAgent =
             (typeof navigator !== "undefined" && navigator.userAgent) || "";
-          var isIE = /Trident/.test(userAgent);
           var isIOSChrome = /CriOS/.test(userAgent);
 
           (function checkOnBlobSupport() {
-            if (isIE || isIOSChrome) {
+            if (isIOSChrome) {
               compatibilityParams.disableCreateObjectURL = true;
             }
           })();

--- a/examples/PDF.js/pdfobject.js
+++ b/examples/PDF.js/pdfobject.js
@@ -38,7 +38,6 @@
     ua = window.navigator.userAgent,
     //declare booleans
     supportsPDFs,
-    isIE,
     supportsPdfMimeType =
       typeof navigator.mimeTypes["application/pdf"] !== "undefined",
     supportsPdfActiveX,
@@ -85,16 +84,6 @@
     return ax;
   };
 
-  //IE11 still uses ActiveX for Adobe Reader, but IE 11 doesn't expose
-  //window.ActiveXObject the same way previous versions of IE did
-  //window.ActiveXObject will evaluate to false in IE 11, but "ActiveXObject" in window evaluates to true
-  //so check the first one for older IE, and the second for IE11
-  //FWIW, MS Edge (replacing IE11) does not support ActiveX at all, both will evaluate false
-  //Constructed as a method (not a prop) to avoid unneccesarry overhead -- will only be evaluated if needed
-  isIE = function() {
-    return !!(window.ActiveXObject || "ActiveXObject" in window);
-  };
-
   //If either ActiveX support for "AcroPDF.PDF" or "PDF.PdfCtrl" are found, return true
   //Constructed as a method (not a prop) to avoid unneccesarry overhead -- will only be evaluated if needed
   supportsPdfActiveX = function() {
@@ -110,9 +99,7 @@
     //Modern versions of Firefox come bundled with PDFJS
     (isFirefoxWithPDFJS ||
       //Browsers that still support the original MIME type check
-      supportsPdfMimeType ||
-      //Pity the poor souls still using IE
-      (isIE() && supportsPdfActiveX()));
+      supportsPdfMimeType);
 
   //Create a fragment identifier for using PDF Open parameters when embedding PDF
   buildFragmentString = function(pdfParams) {

--- a/examples/js/ace.js
+++ b/examples/js/ace.js
@@ -1174,8 +1174,7 @@
           l = { 2: "dblclick", 3: "tripleclick", 4: "quadclick" };
         Array.isArray(e) || (e = [e]),
           e.forEach(function(e) {
-            t.addListener(e, "mousedown", c),
-              i.isOldIE && t.addListener(e, "dblclick", h);
+            t.addListener(e, "mousedown", c);
           });
       });
     var u =
@@ -1229,7 +1228,7 @@
             s || (f(), r(window, "focus", f));
         }
       });
-    if (typeof window == "object" && window.postMessage && !i.isOldIE) {
+    if (typeof window == "object" && window.postMessage) {
       var l = 1;
       t.nextTick = function(e, n) {
         n = n || window;
@@ -1424,15 +1423,12 @@
         }
         function R() {
           clearTimeout(q),
-            (q = setTimeout(
-              function() {
-                p && ((n.style.cssText = p), (p = "")),
-                  t.renderer.$keepTextAreaAtCursor == null &&
-                    ((t.renderer.$keepTextAreaAtCursor = !0),
-                    t.renderer.$moveTextAreaToCursor());
-              },
-              i.isOldIE ? 200 : 0
-            ));
+            (q = setTimeout(function() {
+              p && ((n.style.cssText = p), (p = "")),
+                t.renderer.$keepTextAreaAtCursor == null &&
+                  ((t.renderer.$keepTextAreaAtCursor = !0),
+                  t.renderer.$moveTextAreaToCursor());
+            }, 0));
         }
         var n = s.createElement("textarea");
         (n.className = "ace_text-input"),
@@ -1442,7 +1438,6 @@
           n.setAttribute("autocapitalize", "off"),
           n.setAttribute("spellcheck", !1),
           (n.style.opacity = "0"),
-          i.isOldIE && (n.style.top = "-1000px"),
           e.insertBefore(n, e.firstChild);
         var f = "",
           l = !1,
@@ -1506,27 +1501,6 @@
             } catch (n) {}
             return !t || t.parentElement() != e ? !1 : t.text == e.value;
           }));
-        if (i.isOldIE) {
-          var S = !1,
-            x = function(e) {
-              if (S) return;
-              var t = n.value;
-              if (h || !t || t == f) return;
-              if (e && t == f[0]) return T.schedule();
-              A(t), (S = !0), w(), (S = !1);
-            },
-            T = o.delayedCall(x);
-          r.addListener(n, "propertychange", x);
-          var N = { 13: 1, 27: 1 };
-          r.addListener(n, "keyup", function(e) {
-            h && (!n.value || N[e.keyCode]) && setTimeout(F, 0);
-            if ((n.value.charCodeAt(0) || 0) < 129) return T.call();
-            h ? j() : B();
-          }),
-            r.addListener(n, "keydown", function(e) {
-              T.schedule(50);
-            });
-        }
         var C = function(e) {
             l
               ? (l = !1)
@@ -1698,7 +1672,6 @@
               this.moveToMouse(e, !0);
           }),
           (this.moveToMouse = function(e, o) {
-            if (!o && i.isOldIE) return;
             p || (p = n.style.cssText),
               (n.style.cssText =
                 (o ? "z-index:100000;" : "") +
@@ -1719,7 +1692,7 @@
             t.renderer.$keepTextAreaAtCursor &&
               (t.renderer.$keepTextAreaAtCursor = null),
               clearTimeout(q),
-              i.isWin && !i.isOldIE && r.capture(t.container, h, R);
+              i.isWin && r.capture(t.container, h, R);
           }),
           (this.onContextMenuClose = R);
         var q,
@@ -3003,10 +2976,6 @@
             f = function() {
               s[s.state] && s[s.state](), (s.$mouseMoved = !1);
             };
-          if (i.isOldIE && e.domEvent.type == "dblclick")
-            return setTimeout(function() {
-              a(e);
-            });
           (s.$onCaptureMouseMove = o),
             (s.releaseMouse = r.capture(this.editor.container, o, a));
           var l = setInterval(f, 20);
@@ -12377,7 +12346,7 @@
     var g = function(e, t) {
       var n = this;
       (this.container = e || i.createElement("div")),
-        (this.$keepTextAreaAtCursor = !o.isOldIE),
+        (this.$keepTextAreaAtCursor = true),
         i.addCssClass(this.container, "ace_editor"),
         this.setTheme(t),
         (this.$gutter = i.createElement("div")),

--- a/examples/js/ace.js
+++ b/examples/js/ace.js
@@ -984,19 +984,6 @@
     (t.isWin = r == "win"),
       (t.isMac = r == "mac"),
       (t.isLinux = r == "linux"),
-      (t.isIE =
-        navigator.appName == "Microsoft Internet Explorer" ||
-        navigator.appName.indexOf("MSAppHost") >= 0
-          ? parseFloat(
-              (i.match(
-                /(?:MSIE |Trident\/[0-9]+[\.0-9]+;.*rv:)([0-9]+[\.0-9]+)/
-              ) || [])[1]
-            )
-          : parseFloat(
-              (i.match(/(?:Trident\/[0-9]+[\.0-9]+;.*rv:)([0-9]+[\.0-9]+)/) ||
-                [])[1]
-            )),
-      (t.isOldIE = t.isIE && t.isIE < 9),
       (t.isGecko = t.isMozilla =
         (window.Controllers || window.controllers) &&
         window.navigator.product === "Gecko"),
@@ -1167,15 +1154,6 @@
             : e.detail > 1
             ? (o++, o > 4 && (o = 1))
             : (o = 1);
-          if (i.isIE) {
-            var c = Math.abs(e.clientX - u) > 5 || Math.abs(e.clientY - a) > 5;
-            if (!f || c) o = 1;
-            f && clearTimeout(f),
-              (f = setTimeout(function() {
-                f = null;
-              }, n[o - 1] || 600)),
-              o == 1 && ((u = e.clientX), (a = e.clientY));
-          }
           (e._clicks = o), r[s]("mousedown", e);
           if (o > 4) o = 0;
           else if (o > 1) return r[s](l[o], e);
@@ -1427,7 +1405,6 @@
       s = e("../lib/dom"),
       o = e("../lib/lang"),
       u = i.isChrome < 18,
-      a = i.isIE,
       f = function(e, t) {
         function b(e) {
           if (h) return;
@@ -1591,7 +1568,7 @@
           M = function(e, t, n) {
             var r = e.clipboardData || window.clipboardData;
             if (!r || u) return;
-            var i = a || n ? "Text" : "text/plain";
+            var i = n ? "Text" : "text/plain";
             try {
               return t ? r.setData(i, t) !== !1 : r.getData(i);
             } catch (e) {
@@ -1619,9 +1596,7 @@
           H = function(e) {
             var s = M(e);
             typeof s == "string"
-              ? (s && t.onPaste(s, e),
-                i.isIE && setTimeout(b),
-                r.preventDefault(e))
+              ? (s && t.onPaste(s, e), r.preventDefault(e))
               : ((n.value = ""), (c = !0));
           };
         r.addCommandKeyListener(n, t.onCommandKey.bind(t)),
@@ -1729,8 +1704,7 @@
                 (o ? "z-index:100000;" : "") +
                 "height:" +
                 n.style.height +
-                ";" +
-                (i.isIE ? "opacity:0.1;" : ""));
+                ";");
             var u = t.container.getBoundingClientRect(),
               a = s.computedStyle(t.container),
               f = u.top + (parseInt(a.borderTopWidth) || 0),
@@ -2493,15 +2467,6 @@
         }),
         (this.onMouseDrag = function(e) {
           var t = this.editor.container;
-          if (s.isIE && this.state == "dragReady") {
-            var n = l(
-              this.mousedownEvent.x,
-              this.mousedownEvent.y,
-              this.x,
-              this.y
-            );
-            n > 3 && t.dragDrop();
-          }
           if (this.state === "dragWait") {
             var n = l(
               this.mousedownEvent.x,
@@ -2972,10 +2937,6 @@
           ),
           r.addListener(u, "mousedown", n),
           r.addListener(f, "mousedown", n),
-          i.isIE &&
-            e.renderer.scrollBarV &&
-            (r.addListener(e.renderer.scrollBarV.element, "mousedown", n),
-            r.addListener(e.renderer.scrollBarH.element, "mousedown", n)),
           e.on("mousemove", function(n) {
             if (t.state || t.$dragDelay || !t.$dragEnabled) return;
             var r = e.renderer.screenToTextCoordinates(n.x, n.y),
@@ -12306,7 +12267,7 @@
             (e.visibility = "hidden"),
             (e.position = "absolute"),
             (e.whiteSpace = "pre"),
-            o.isIE < 8 ? (e["font-family"] = "inherit") : (e.font = "inherit"),
+            (e.font = "inherit"),
             (e.overflow = t ? "hidden" : "visible");
         }),
         (this.checkForSizeChanges = function() {

--- a/examples/js/pdfobject.min.js
+++ b/examples/js/pdfobject.min.js
@@ -22,7 +22,6 @@
   var pdfobjectversion = "2.1.1",
     ua = window.navigator.userAgent,
     supportsPDFs,
-    isIE,
     supportsPdfMimeType =
       typeof navigator.mimeTypes["application/pdf"] !== "undefined",
     supportsPdfActiveX,
@@ -58,17 +57,7 @@
     }
     return ax;
   };
-  isIE = function() {
-    return !!(window.ActiveXObject || "ActiveXObject" in window);
-  };
-  supportsPdfActiveX = function() {
-    return !!(createAXO("AcroPDF.PDF") || createAXO("PDF.PdfCtrl"));
-  };
-  supportsPDFs =
-    !isIOS &&
-    (isFirefoxWithPDFJS ||
-      supportsPdfMimeType ||
-      (isIE() && supportsPdfActiveX()));
+  supportsPDFs = !isIOS && (isFirefoxWithPDFJS || supportsPdfMimeType);
   buildFragmentString = function(pdfParams) {
     var string = "",
       prop;

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
       "optionalDependencies": {
         "canvg": "^3.0.6",
         "core-js": "^3.6.0",
-        "dompurify": "^2.5.8",
+        "dompurify": "^3.2.4",
         "html2canvas": "^1.0.0-rc.5"
       }
     },
@@ -1853,6 +1853,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/yauzl": {
       "version": "2.9.1",
@@ -4670,11 +4677,14 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dot-case": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "optionalDependencies": {
     "canvg": "^3.0.6",
     "core-js": "^3.6.0",
-    "dompurify": "^2.5.8",
+    "dompurify": "^3.2.4",
     "html2canvas": "^1.0.0-rc.5"
   },
   "devDependencies": {
@@ -110,7 +110,6 @@
     "generate-docs": "jsdoc -c jsdoc.json --readme README.md"
   },
   "browserslist": [
-    "last 2 versions",
-    "IE 11"
+    "last 2 versions"
   ]
 }

--- a/src/libs/Blob.js
+++ b/src/libs/Blob.js
@@ -415,26 +415,6 @@ if (strTag) {
 }
 
 function fixFileAndXHR() {
-  var isIE =
-    !!global.ActiveXObject ||
-    ("-ms-scroll-limit" in document.documentElement.style &&
-      "-ms-ime-align" in document.documentElement.style);
-
-  // Monkey patched
-  // IE don't set Content-Type header on XHR whose body is a typed Blob
-  // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/6047383
-  var _send = global.XMLHttpRequest && global.XMLHttpRequest.prototype.send;
-  if (isIE && _send) {
-    XMLHttpRequest.prototype.send = function(data) {
-      if (data instanceof Blob) {
-        this.setRequestHeader("Content-Type", data.type);
-        _send.call(this, data);
-      } else {
-        _send.call(this, data);
-      }
-    };
-  }
-
   try {
     new File([], "");
   } catch (e) {

--- a/test/karma.common.conf.js
+++ b/test/karma.common.conf.js
@@ -27,7 +27,7 @@ var karmaConfig = {
   // if true, Karma captures browsers, runs the tests and exits
   singleRun: false,
 
-  browsers: ["Chrome", "Firefox", "IE"],
+  browsers: ["Chrome", "Firefox"],
 
   // Concurrency level
   // how many browser should be started simultaneous

--- a/test/saucelabs/karma.conf.js
+++ b/test/saucelabs/karma.conf.js
@@ -3,12 +3,6 @@
 const karmaConfig = require("../karma.common.conf.js");
 
 const browsers = {
-  sl_ie_11: {
-    base: "SauceLabs",
-    browserName: "internet explorer",
-    platform: "Windows 10",
-    version: "11"
-  },
   sl_chrome: {
     base: "SauceLabs",
     browserName: "chrome",


### PR DESCRIPTION
Resolve #3819 

Remove MSIE support as CVE-2025-26791 affects `dompurify` v2 and the only resolution is to bump to `dompurify` v3. However, the new major version [dropped support for MSIE](https://github.com/cure53/DOMPurify/releases/tag/3.0.0) so `jspdf` must do the same.

