### PR TITLE
Upgrade canvg from 3.0.6 to 3.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "yarpm": "^0.2.1"
       },
       "optionalDependencies": {
-        "canvg": "^3.0.6",
+        "canvg": "^3.0.11",
         "core-js": "^3.6.0",
         "dompurify": "^3.2.4",
         "html2canvas": "^1.0.0-rc.5"
@@ -3363,20 +3363,22 @@
       }
     },
     "node_modules/canvg": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.6.tgz",
-      "integrity": "sha512-eFUy8R/4DgocR93LF8lr+YUxW4PYblUe/Q1gz2osk/cI5n8AsYdassvln0D9QPhLXQ6Lx7l8hwtT8FLvOn2Ihg==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
       "optional": true,
       "dependencies": {
-        "@babel/runtime": "^7.6.3",
+        "@babel/runtime": "^7.12.5",
         "@types/raf": "^3.4.0",
-        "core-js": "3",
+        "core-js": "^3.8.3",
         "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
         "rgbcolor": "^1.0.1",
-        "stackblur-canvas": "^2.0.0"
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/capital-case": {
@@ -9876,10 +9878,10 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "devOptional": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -11487,6 +11489,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/table": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fflate": "^0.8.1"
   },
   "optionalDependencies": {
-    "canvg": "^3.0.6",
+    "canvg": "^3.0.11",
     "core-js": "^3.6.0",
     "dompurify": "^3.2.4",
     "html2canvas": "^1.0.0-rc.5"


### PR DESCRIPTION
Upgraded canvg from 3.0.6 to 3.0.11 to fix the Snyk vulnerability: [SNYK-JS-CANVG-8663318](https://security.snyk.io/vuln/SNYK-JS-CANVG-8663318).

Resolves #3834 

Release notes canvg: [v3.0.11](https://github.com/canvg/canvg/releases/tag/v3.0.11).

(For some reason, test-unit is failing with 8 unit tests on a fresh master branch and after upgrading the canvg package.
However, when running only Firefox by editing the Karma config, the tests pass.)

Failing environment:

- Chrome 134.0.0.0 (Windows 10, Module: html)