### PR TITLE
BugFix for Issue#3797

### DIFF
--- a/dist/jspdf.umd.js
+++ b/dist/jspdf.umd.js
@@ -23167,10 +23167,6 @@
         d[e + 3] = 255;
       }
 
-      function ga(a, b) {
-        return 0 > a ? 0 : a > b ? b : a;
-      }
-
       function la(a, b, c) {
         self[a] = function (a, e, f, g, h, k, l, m, n) {
           for (var d = m + (n & -2) * c; m != d;) {


### PR DESCRIPTION
The jspdf.umd.js file on lines 21461 and 23170 there are identical method declarations. You may also find these by searching for "function ga(a, b)" and jumping to each. I needed to precompile my entire rails project with this included and the duplicate method declaration caused an error. I was able to remove the duplicate at line 23170, compile, and everything seemed to work fine.

Thanks for contributing to jsPDF! Please follow our
[Contribution Guidelines](https://github.com/MrRio/jsPDF/blob/master/CONTRIBUTING.md#pull-requests)
when creating a pull request.
