### PR TITLE
fix: cell function now properly accepts align parameter

### DIFF
--- a/src/modules/cell.js
+++ b/src/modules/cell.js
@@ -278,7 +278,8 @@ import { jsPDF } from "../jspdf.js";
         arguments[2],
         arguments[3],
         arguments[4],
-        arguments[5]
+        arguments[5],
+        arguments[6]
       );
     }
     _initialize.call(this);


### PR DESCRIPTION
- Fixed missing align parameter (arguments[6]) in Cell constructor call
- The cell function was documented to accept 7 parameters including align
- Previously only 6 parameters were passed, causing alignment to be ignored
- Now alignment works correctly for 'left', 'center', and 'right' values
- All existing tests continue to pass

Fixes: #3194

@HackbrettXXX Please verify the changes, Thanks.
