### PR TITLE
Fix pages property to always return current array reference ( #3898 )

### DIFF
--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -6043,7 +6043,7 @@ function jsPDF(options) {
     getEncryptor: getEncryptor,
     output: output,
     getNumberOfPages: getNumberOfPages,
-    pages: pages,
+    get pages () { return pages },
     out: out,
     f2: f2,
     f3: f3,


### PR DESCRIPTION
Previously, the pages array reference was exposed directly, which caused issues when the internal reference changed. Using a getter ensures that the current pages array is always returned.
