### PR TITLE
Fix putImage mutating the global filters array

### DIFF
--- a/src/modules/addimage.js
+++ b/src/modules/addimage.js
@@ -203,7 +203,11 @@ import { atob } from "../libs/AtobBtoa.js";
     var putStream = this.internal.putStream;
     var getFilters = this.internal.getFilters;
 
-    var filter = getFilters();
+    // getFilters() returns the live reference to the document-wide filters
+    // array. Copy it before mutating so we don't strip FlateEncode from
+    // subsequent output() calls (which would emit page content streams
+    // uncompressed after the first call to putImage).
+    var filter = getFilters().slice();
     while (filter.indexOf("FlateEncode") !== -1) {
       filter.splice(filter.indexOf("FlateEncode"), 1);
     }

--- a/test/specs/addimage.spec.js
+++ b/test/specs/addimage.spec.js
@@ -64,7 +64,9 @@ describe("Module: addimage", () => {
       canvas.width = 0;
       canvas.height = 100;
 
-      var expectedError = new Error("Given canvas must have data. Canvas width: 0, height: 100");
+      var expectedError = new Error(
+        "Given canvas must have data. Canvas width: 0, height: 100"
+      );
 
       expect(function() {
         doc.addImage(canvas, 10, 10);
@@ -92,4 +94,18 @@ describe("Module: addimage", () => {
       }).not.toThrow();
     });
   }
+
+  it("repeated output() after addImage produces identical PDFs (regression: putImage was mutating the global filters array)", () => {
+    const doc = new jsPDF({ compress: true });
+    doc.addImage(jpg, "JPEG", 10, 10, 100, 75);
+
+    const out1 = doc.output();
+    const out2 = doc.output();
+    const out3 = doc.output();
+
+    expect(out2.length).toEqual(out1.length);
+    expect(out3.length).toEqual(out1.length);
+    expect(out2).toEqual(out1);
+    expect(out3).toEqual(out1);
+  });
 });


### PR DESCRIPTION
## Problem

`putImage` calls `splice()` on the array returned by `getFilters()` to remove `"FlateEncode"` before writing image data. But `getFilters()` returns the **live reference** to the document's internal filters array, not a copy:

https://github.com/parallax/jsPDF/blob/master/src/jspdf.js#L1748-L1750

```js
var getFilters = (API.__private__.getFilters = function() {
  return filters;
});
```

So the splice in `putImage` permanently empties the document's filters array. After the first image is rendered, **all subsequent page content streams are emitted without compression**.

## Symptoms

Calling `doc.output()` twice in a row on a document containing any image produces PDFs of dramatically different sizes:

```js
const doc = new jsPDF({ compress: true });
doc.addImage(jpg, "JPEG", 10, 10, 100, 75);

const a = doc.output();
const b = doc.output();

console.log(a.length, b.length);
// → 5440, 110xxx   (page content stream goes from FlateEncoded ~5KB to raw ~100KB)
```

The first output is correct; every output after that has uncompressed page content streams. The PDF still renders fine in viewers, just much larger than expected.

## Cause

[`src/modules/addimage.js` line 206-208](https://github.com/parallax/jsPDF/blob/master/src/modules/addimage.js#L206-L208):

```js
var filter = getFilters();
while (filter.indexOf("FlateEncode") !== -1) {
  filter.splice(filter.indexOf("FlateEncode"), 1);
}
```

Since `filter` and the document's internal `filters` are the same array reference, the splice strips `"FlateEncode"` from the document-wide configuration.

## Fix

One-line change: copy the array before mutating.

```js
var filter = getFilters().slice();
```

`putImage` still gets its local "filters minus FlateEncode" list, and the document's `filters` array is unaffected.

## Test

Added a regression test in `test/specs/addimage.spec.js` that asserts repeated `doc.output()` calls return identical buffers. All 541 unit tests pass locally.

## Notes

- I did not regenerate `dist/` per the CONTRIBUTING guideline.
- Discovered while debugging cumulative PDF growth in a library that wraps jsPDF for `canvas-editor-pdf`. Happy to add more context if useful.
