### PR TITLE
Update TypeScript version in typings tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         ts-version:
           - { ts: '4.0', types-node: '17' }
-          - { ts: 'latest', types-node: '20' }
+          - { ts: '^5', types-node: '20' }
     name: Typings tests (typescript@${{ matrix.ts-version.ts }})
     steps:
       - name: Checkout


### PR DESCRIPTION
`typescript@latest` is a moving target which has moved to v6 which in turn breaks a project dependency (karma-typescript) and fails the type tests.

Being compatible with latest version ts versions is desirable, but should not break predictability in CI. If support for newest version is wanted we should plan to replace the deprecated karma-typescript package and add v6 to the matrix in a separate PR.

Current workflow blocks security patches and PR's:

#3988 #3985 #3976 #3975 #3973 #3972 #3971 