### PR TITLE
Respect charSpace when wrapping text with maxWidth

### DIFF
--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -3701,11 +3701,14 @@ function jsPDF(options) {
     maxWidth = options.maxWidth || 0;
 
     if (maxWidth > 0) {
+      var splitOptions = { charSpace: options.charSpace };
       if (typeof text === "string") {
-        text = scope.splitTextToSize(text, maxWidth);
+        text = scope.splitTextToSize(text, maxWidth, splitOptions);
       } else if (Object.prototype.toString.call(text) === "[object Array]") {
         text = text.reduce(function(acc, textLine) {
-          return acc.concat(scope.splitTextToSize(textLine, maxWidth));
+          return acc.concat(
+            scope.splitTextToSize(textLine, maxWidth, splitOptions)
+          );
         }, []);
       }
     }

--- a/src/modules/split_text_to_size.js
+++ b/src/modules/split_text_to_size.js
@@ -92,7 +92,8 @@ import { jsPDF } from "../jspdf.js";
         }
         output.push(
           (widths[char_code] || default_char_width) / widthsFractionOf +
-            kerningValue
+            kerningValue +
+            charSpace / fontSize
         );
       }
       prior_char_code = char_code;
@@ -376,6 +377,7 @@ import { jsPDF } from "../jspdf.js";
       ? (options.textIndent * 1.0 * this.internal.scaleFactor) / fsize
       : 0;
     newOptions.lineIndent = options.lineIndent;
+    newOptions.charSpace = options.charSpace;
 
     var i,
       l,

--- a/test/specs/split_text_to_size.spec.js
+++ b/test/specs/split_text_to_size.spec.js
@@ -209,4 +209,36 @@ describe("Module: split_text_to_size", () => {
       )[4]
     ).toEqual("voluptua.");
   });
+
+  it("splitTextToSize respects charSpace (#3299)", () => {
+    var doc = new jsPDF();
+    doc.setFont("Helvetica");
+    doc.setFontSize(16);
+
+    var str =
+      "Mary had a little lamb she also had a duck. She put them on the mantlepiece to see if they would fall off.";
+    var maxWidth = 100;
+    var charSpace = 1;
+    var fontSize = 16;
+    var scaleFactor = doc.internal.scaleFactor;
+
+    var lines = doc.splitTextToSize(str, maxWidth, { charSpace: charSpace });
+
+    // Every resulting line must still fit within maxWidth once charSpace is applied.
+    lines.forEach(function(line) {
+      var lineWidth =
+        (doc.getStringUnitWidth(line, {
+          charSpace: charSpace,
+          fontSize: fontSize
+        }) *
+          fontSize) /
+        scaleFactor;
+      expect(lineWidth).toBeLessThanOrEqual(maxWidth);
+    });
+
+    // Wider character spacing wraps the text into more lines than no spacing.
+    expect(lines.length).toBeGreaterThan(
+      doc.splitTextToSize(str, maxWidth, { charSpace: 0 }).length
+    );
+  });
 });


### PR DESCRIPTION
When `maxWidth` is set, `doc.text()` wraps via `splitTextToSize()`, but the per-call `charSpace` never reached the width measurement used for wrapping, so text wrapped as if `charSpace` were 0 and then overflowed `maxWidth` once the spacing was rendered.

- Forward `charSpace` from `text()` into `splitTextToSize()`
- Thread it through the per-paragraph options and add `charSpace / fontSize` per character in the standard-font width branch (same units the embedded-font branch already uses)
- Add a spec asserting wrapped lines fit within `maxWidth` and that a wider `charSpace` wraps into more lines

No public API change, so `types/index.d.ts` is untouched. The new spec fails without the fix and passes with it; `npm run test-node` passes (468 specs, 4 pre-existing pending) and prettier is clean on the changed files.

Fixes #3299